### PR TITLE
refactor: extract activeUsers helper for filterAttrs fullName pattern

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -155,9 +155,9 @@
         in
         {
           config = {
-            # Make appHelpers available to all modules
+            # Make helpers available to all modules
             _module.args = {
-              inherit (mynixosLib) appHelpers;
+              inherit (mynixosLib) appHelpers activeUsers;
             };
           };
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -6,4 +6,9 @@
 
   # App helper utilities for category-based enabling
   appHelpers = import ./app-helpers.nix { inherit lib; };
+
+  # Filter users to only those with fullName defined (fully configured users)
+  # Users without fullName are partial configs (mounts, yubikeys, email only)
+  # Usage: activeUsers config.my.users
+  activeUsers = lib.filterAttrs (_: u: u.fullName or null != null);
 }

--- a/my/audio/default.nix
+++ b/my/audio/default.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ activeUsers, config, lib, pkgs, ... }:
 
 with lib;
 
@@ -31,7 +31,7 @@ in
       (_name: _userCfg: {
         extraGroups = [ "audio" ];
       })
-      (filterAttrs (_name: userCfg: userCfg.fullName or null != null) config.my.users);
+      (activeUsers config.my.users);
 
     # Audio utilities
     environment.systemPackages = with pkgs; [

--- a/my/dev/development/default.nix
+++ b/my/dev/development/default.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ activeUsers, config, lib, pkgs, ... }:
 
 with lib;
 
@@ -20,7 +20,7 @@ in
         (_name: _userCfg: {
           extraGroups = [ "disk" "dialout" ];
         })
-        (filterAttrs (_name: userCfg: userCfg.fullName or null != null) config.my.users);
+        (activeUsers config.my.users);
     })
 
     # Docker - runs as user (rootless)
@@ -39,7 +39,7 @@ in
         (_name: userCfg: {
           extraGroups = mkIf ((userCfg.dev.enable or false) && (userCfg.dev.docker.enable or true)) [ "docker" ];
         })
-        (filterAttrs (_name: userCfg: userCfg.fullName or null != null) config.my.users);
+        (activeUsers config.my.users);
 
       # Docker tools
       environment.systemPackages = with pkgs; [

--- a/my/graphical/default.nix
+++ b/my/graphical/default.nix
@@ -1,4 +1,5 @@
-{ config
+{ activeUsers
+, config
 , lib
 , pkgs
 , ...
@@ -137,7 +138,7 @@ in
               "render"
             ];
           })
-          (filterAttrs (_name: userCfg: userCfg.fullName or null != null) config.my.users);
+          (activeUsers config.my.users);
       }
 
       # Audio tools are now in my.hardware.audio, not in graphical

--- a/my/security/default.nix
+++ b/my/security/default.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ activeUsers, config, lib, pkgs, ... }:
 
 with lib;
 
@@ -114,7 +114,7 @@ in
                 ) userCfg.yubikeys}"
                 else ""
               )
-              (lib.filterAttrs (_name: userCfg: userCfg.fullName or null != null) config.my.users)
+              (activeUsers config.my.users)
           )
         );
 
@@ -174,7 +174,7 @@ in
           (_name: _userCfg: {
             extraGroups = [ "plugdev" "pcscd" ];
           })
-          (filterAttrs (_name: userCfg: userCfg.fullName or null != null) config.my.users);
+          (activeUsers config.my.users);
       };
     })
 

--- a/my/streaming/default.nix
+++ b/my/streaming/default.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ activeUsers, config, lib, pkgs, ... }:
 
 with lib;
 
@@ -36,7 +36,7 @@ in
           (_name: _userCfg: {
             extraGroups = [ "udev" "usb" "audio" ];
           })
-          (filterAttrs (_name: userCfg: userCfg.fullName or null != null) config.my.users);
+          (activeUsers config.my.users);
       }
 
       # Default to enable video.virtual when any user has streaming enabled

--- a/my/users/users/default.nix
+++ b/my/users/users/default.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ activeUsers, config, lib, pkgs, ... }:
 
 with lib;
 
@@ -15,7 +15,7 @@ let
 
   # Only create users that have fullName defined (fully configured users)
   # Users with only mounts/email/yubikeys defined won't be created (they come from myLib.users)
-  usersToCreate = filterAttrs (_name: userCfg: userCfg.fullName or null != null) cfg;
+  usersToCreate = activeUsers cfg;
 
   # Get users that want sops-managed passwords
   usersWithSopsPassword = filterAttrs


### PR DESCRIPTION
## Summary

- Added `activeUsers` helper to `lib/default.nix` that wraps the repeated `filterAttrs (_: u: u.fullName or null != null)` pattern
- Exposed `activeUsers` to all modules via `_module.args` (same mechanism as `appHelpers`)
- Replaced all 8 inline occurrences across 6 files: `my/users/users/default.nix`, `my/audio/default.nix`, `my/dev/development/default.nix`, `my/streaming/default.nix`, `my/security/default.nix`, `my/graphical/default.nix`

## Test plan

- [ ] `nix flake check` passes
- [ ] `nix fmt -- --check .` passes
- [ ] `statix check .` passes
- [ ] `deadnix --fail .` passes
- [ ] System builds correctly with the refactored helper

Closes #45