### PR TITLE
refactor: extract shared flake discovery script

### DIFF
--- a/my/system/scripts/default.nix
+++ b/my/system/scripts/default.nix
@@ -4,6 +4,28 @@ with lib;
 
 let
   cfg = config.my.system;
+
+  # Shared flake discovery snippet used by all system scripts.
+  # Sets FLAKE_DIR to the first directory containing flake.nix.
+  findFlakeDir = ''
+    if [ -d "/etc/nixos" ] && [ -f "/etc/nixos/flake.nix" ]; then
+      FLAKE_DIR="/etc/nixos"
+    elif [ -d "$HOME/.flake" ] && [ -f "$HOME/.flake/flake.nix" ]; then
+      FLAKE_DIR="$HOME/.flake"
+    else
+      echo "Error: Could not find flake.nix in /etc/nixos or ~/.flake"
+      exit 1
+    fi
+  '';
+
+  # Detect the appropriate rebuild command based on platform.
+  detectRebuildCmd = action: ''
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+      REBUILD_CMD="darwin-rebuild ${action} --flake"
+    else
+      REBUILD_CMD="nixos-rebuild ${action} --flake"
+    fi
+  '';
 in
 {
   config = mkIf cfg.enable {
@@ -13,17 +35,9 @@ in
       (pkgs.writeScriptBin "update-system" ''
         #!/usr/bin/env bash
         # Update flake inputs for the system configuration
-        # Detects the flake location based on common paths
-        
-        if [ -d "/etc/nixos" ] && [ -f "/etc/nixos/flake.nix" ]; then
-          FLAKE_DIR="/etc/nixos"
-        elif [ -d "$HOME/.flake" ] && [ -f "$HOME/.flake/flake.nix" ]; then
-          FLAKE_DIR="$HOME/.flake"
-        else
-          echo "Error: Could not find flake.nix in /etc/nixos or ~/.flake"
-          exit 1
-        fi
-        
+
+        ${findFlakeDir}
+
         echo "Updating flake inputs in $FLAKE_DIR..."
         cd "$FLAKE_DIR"
         nix flake update
@@ -33,25 +47,10 @@ in
       (pkgs.writeScriptBin "rebuild-system" ''
         #!/usr/bin/env bash
         # Rebuild and switch to new system configuration
-        # Detects the flake location and uses appropriate rebuild command
-        
-        # Determine rebuild command based on platform
-        if [[ "$OSTYPE" == "darwin"* ]]; then
-          REBUILD_CMD="darwin-rebuild switch --flake"
-        else
-          REBUILD_CMD="nixos-rebuild switch --flake"
-        fi
-        
-        # Detect flake location
-        if [ -d "/etc/nixos" ] && [ -f "/etc/nixos/flake.nix" ]; then
-          FLAKE_DIR="/etc/nixos"
-        elif [ -d "$HOME/.flake" ] && [ -f "$HOME/.flake/flake.nix" ]; then
-          FLAKE_DIR="$HOME/.flake"
-        else
-          echo "Error: Could not find flake.nix in /etc/nixos or ~/.flake"
-          exit 1
-        fi
-        
+
+        ${detectRebuildCmd "switch"}
+        ${findFlakeDir}
+
         echo "Rebuilding system from $FLAKE_DIR..."
         cd "$FLAKE_DIR"
         sudo $REBUILD_CMD .#
@@ -61,25 +60,10 @@ in
       (pkgs.writeScriptBin "test-system" ''
         #!/usr/bin/env bash
         # Test system configuration without creating bootloader entry
-        # Useful for testing changes before committing
-        
-        # Determine rebuild command based on platform
-        if [[ "$OSTYPE" == "darwin"* ]]; then
-          REBUILD_CMD="darwin-rebuild test --flake"
-        else
-          REBUILD_CMD="nixos-rebuild test --flake"
-        fi
-        
-        # Detect flake location
-        if [ -d "/etc/nixos" ] && [ -f "/etc/nixos/flake.nix" ]; then
-          FLAKE_DIR="/etc/nixos"
-        elif [ -d "$HOME/.flake" ] && [ -f "$HOME/.flake/flake.nix" ]; then
-          FLAKE_DIR="$HOME/.flake"
-        else
-          echo "Error: Could not find flake.nix in /etc/nixos or ~/.flake"
-          exit 1
-        fi
-        
+
+        ${detectRebuildCmd "test"}
+        ${findFlakeDir}
+
         echo "Testing system configuration from $FLAKE_DIR..."
         cd "$FLAKE_DIR"
         sudo $REBUILD_CMD .#
@@ -89,25 +73,10 @@ in
       (pkgs.writeScriptBin "build-system" ''
         #!/usr/bin/env bash
         # Build system configuration without activating
-        # Useful for checking for build errors
-        
-        # Determine rebuild command based on platform
-        if [[ "$OSTYPE" == "darwin"* ]]; then
-          REBUILD_CMD="darwin-rebuild build --flake"
-        else
-          REBUILD_CMD="nixos-rebuild build --flake"
-        fi
-        
-        # Detect flake location
-        if [ -d "/etc/nixos" ] && [ -f "/etc/nixos/flake.nix" ]; then
-          FLAKE_DIR="/etc/nixos"
-        elif [ -d "$HOME/.flake" ] && [ -f "$HOME/.flake/flake.nix" ]; then
-          FLAKE_DIR="$HOME/.flake"
-        else
-          echo "Error: Could not find flake.nix in /etc/nixos or ~/.flake"
-          exit 1
-        fi
-        
+
+        ${detectRebuildCmd "build"}
+        ${findFlakeDir}
+
         echo "Building system configuration from $FLAKE_DIR..."
         cd "$FLAKE_DIR"
         sudo $REBUILD_CMD .#


### PR DESCRIPTION
## Summary
- Extract shared `findFlakeDir` and `detectRebuildCmd` helpers in `my/system/scripts/default.nix`
- Deduplicate flake directory detection logic across `update-system`, `rebuild-system`, `test-system`, and `build-system` scripts
- Net reduction: 68 deletions, 37 insertions

Note: The original issue #43 referenced `my/users/apps/` modules, but the actual duplication was in system scripts. The user-facing app modules use a different flake-related pattern.

Closes #43