### PR TITLE
refactor: standardize allowUnfreePredicate into single source

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -189,6 +189,7 @@
             ./my/system/core
             ./my/system/kernel
             ./my/system/scripts
+            ./my/system/unfree
 
             # Themes
             ./my/themes

--- a/my/system/options.nix
+++ b/my/system/options.nix
@@ -26,6 +26,12 @@
 
         enable = lib.mkEnableOption "core system utilities (console, nix, boot configuration, plymouth)";
 
+        allowedUnfreePackages = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          description = "List of unfree package names to allow. Modules append to this list and a single predicate is built centrally.";
+        };
+
         persistence = lib.mkOption {
           description = "System persistence configuration";
           default = { };

--- a/my/system/unfree/default.nix
+++ b/my/system/unfree/default.nix
@@ -1,0 +1,23 @@
+{ config, lib, ... }:
+
+with lib;
+
+let
+  allowedPackages = config.my.system.allowedUnfreePackages;
+  hasAllowedPackages = allowedPackages != [ ];
+in
+{
+  config = mkIf hasAllowedPackages {
+    # Single centralized unfree predicate at the NixOS level
+    nixpkgs.config.allowUnfreePredicate = pkg:
+      builtins.elem (lib.getName pkg) allowedPackages;
+
+    # Propagate the same predicate to all home-manager users
+    home-manager.users = mapAttrs
+      (_name: _userCfg: {
+        nixpkgs.config.allowUnfreePredicate = pkg:
+          builtins.elem (lib.getName pkg) allowedPackages;
+      })
+      config.my.users;
+  };
+}

--- a/my/themes/vogix/default.nix
+++ b/my/themes/vogix/default.nix
@@ -21,12 +21,8 @@ in
     # Add vogix overlay to make pkgs.vogix available
     nixpkgs.overlays = [ vogix.overlays.default ];
 
-    # Allow vogix unfree license at NixOS level
-    nixpkgs.config.allowUnfreePredicate =
-      pkg:
-      builtins.elem (lib.getName pkg) [
-        "vogix"
-      ];
+    # Allow vogix unfree license
+    my.system.allowedUnfreePackages = [ "vogix" ];
 
     # Enable vogix at the NixOS level (console colors, etc.)
     vogix.enable = true;
@@ -41,13 +37,6 @@ in
           in
           mkIf userEnabled {
             imports = [ vogix.homeManagerModules.default ];
-
-            # Allow vogix unfree license in home-manager context
-            nixpkgs.config.allowUnfreePredicate =
-              pkg:
-              builtins.elem (lib.getName pkg) [
-                "vogix"
-              ];
 
             programs.vogix = {
               enable = true;

--- a/my/users/apps/browsers/chromium/default.nix
+++ b/my/users/apps/browsers/chromium/default.nix
@@ -23,13 +23,12 @@ in
         config.my.users;
     }
 
-    # System-level unfree allowance (when ANY user enables it)
+    # Allow chromium unfree packages (when ANY user enables it)
     (mkIf anyUserChromium {
-      nixpkgs.config.allowUnfreePredicate = pkg:
-        builtins.elem (pkg.pname or pkg.name or (lib.getName pkg)) [
-          "chromium"
-          "chromium-unwrapped"
-        ];
+      my.system.allowedUnfreePackages = [
+        "chromium"
+        "chromium-unwrapped"
+      ];
     })
   ];
 }

--- a/my/users/apps/dev/vscode/default.nix
+++ b/my/users/apps/dev/vscode/default.nix
@@ -11,11 +11,10 @@ with lib;
     ];
 
     # Allow VSCode (unfree)
-    nixpkgs.config.allowUnfreePredicate = pkg:
-      builtins.elem (pkg.pname or pkg.name or (lib.getName pkg)) [
-        "vscode"
-        "vscode-with-extensions"
-      ];
+    my.system.allowedUnfreePackages = [
+      "vscode"
+      "vscode-with-extensions"
+    ];
 
     # Per-user VSCode installation via home-manager
     home-manager.users = mapAttrs

--- a/my/users/apps/security/1password/default.nix
+++ b/my/users/apps/security/1password/default.nix
@@ -15,12 +15,11 @@ in
       programs._1password.enable = true;
       programs._1password-gui.enable = true;
 
-      nixpkgs.config.allowUnfreePredicate = pkg:
-        builtins.elem (pkg.pname or pkg.name or (lib.getName pkg)) [
-          "1password-gui"
-          "1password"
-          "1password-cli"
-        ];
+      my.system.allowedUnfreePackages = [
+        "1password-gui"
+        "1password"
+        "1password-cli"
+      ];
     })
   ];
 }

--- a/my/users/webapps/default.nix
+++ b/my/users/webapps/default.nix
@@ -68,9 +68,12 @@ in
 {
   config = mkIf anyUserWebapps (mkMerge [
     # Allow unfree packages for webapps (chromium, widevine, etc.)
-    # Use allowUnfree = true instead of predicate to ensure it works at all evaluation levels
     {
-      nixpkgs.config.allowUnfree = true;
+      my.system.allowedUnfreePackages = [
+        "chromium"
+        "chromium-unwrapped"
+        "widevine-cdm"
+      ];
     }
 
     # Electron apps
@@ -95,13 +98,6 @@ in
             userWebapps = userCfg.graphical.webapps or { };
           in
           mkIf (userCfg.graphical.webapps.enable or false) {
-            # Allow chromium unfree in home-manager context
-            nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [
-              "chromium"
-              "chromium-unwrapped"
-              "widevine-cdm"
-            ];
-
             # Icon theme packages
             home.packages = with pkgs; [
               papirus-icon-theme


### PR DESCRIPTION
## Summary

- Adds `my.system.allowedUnfreePackages` option (list of package names) to centralize unfree package management
- Creates `my/system/unfree/default.nix` that builds a single `allowUnfreePredicate` from the aggregated list, applied at both NixOS and home-manager levels
- Migrates all 5 in-module predicate definitions (vscode, 1password, chromium, vogix, webapps) to append to the shared list
- Removes the overly broad `nixpkgs.config.allowUnfree = true` from webapps module
- Leaves `images/default.nix` unchanged as it uses a standalone nixpkgs import outside the module system

## Locations changed

| Module | Before | After |
|--------|--------|-------|
| `my/users/webapps/default.nix` | `allowUnfree = true` + per-user predicate | `my.system.allowedUnfreePackages` |
| `my/users/apps/dev/vscode/default.nix` | inline predicate | `my.system.allowedUnfreePackages` |
| `my/users/apps/security/1password/default.nix` | inline predicate | `my.system.allowedUnfreePackages` |
| `my/users/apps/browsers/chromium/default.nix` | inline predicate | `my.system.allowedUnfreePackages` |
| `my/themes/vogix/default.nix` | NixOS + home-manager predicates | `my.system.allowedUnfreePackages` |

## Test plan

- [ ] Verify `nix flake check` passes
- [ ] Verify `nix fmt -- --check .` passes
- [ ] Verify `statix check .` passes
- [ ] Verify `deadnix --fail .` passes
- [ ] Test on a system with unfree packages (vscode, chromium, 1password, vogix) to confirm they still install correctly

Closes #44