### PR TITLE
refactor: replace attrsOf anything with proper types

### DIFF
--- a/my/environment/options.nix
+++ b/my/environment/options.nix
@@ -37,13 +37,29 @@
                 type = lib.types.submodule {
                   options = {
                     settings = lib.mkOption {
-                      type = lib.types.attrsOf lib.types.anything;
-                      default = {
-                        default_session = {
-                          command = "Hyprland";
-                          user = "greeter";
+                      type = lib.types.submodule {
+                        options = {
+                          default_session = lib.mkOption {
+                            type = lib.types.submodule {
+                              options = {
+                                command = lib.mkOption {
+                                  type = lib.types.str;
+                                  default = "Hyprland";
+                                  description = "Command to run for the default session";
+                                };
+                                user = lib.mkOption {
+                                  type = lib.types.str;
+                                  default = "greeter";
+                                  description = "User to run the greeter as";
+                                };
+                              };
+                            };
+                            default = { };
+                            description = "Default session configuration";
+                          };
                         };
                       };
+                      default = { };
                       description = "greetd settings (mynixos default: tuigreet with Hyprland)";
                     };
                   };

--- a/my/users/defaults/default.nix
+++ b/my/users/defaults/default.nix
@@ -20,6 +20,9 @@ let
             type = types.enum validPrograms;
             description = "Program name";
           };
+          # types.anything is intentional: settings are passed through to varying
+          # home-manager program modules (programs.firefox, programs.kitty, etc.)
+          # whose schemas differ per program and are validated downstream.
           settings = mkOption {
             type = types.attrsOf types.anything;
             default = { };

--- a/my/users/users/apps-options.nix
+++ b/my/users/users/apps-options.nix
@@ -294,6 +294,9 @@ in
                             default = 0.0;
                             description = "Mouse sensitivity (range: -1.0 to 1.0)";
                           };
+                          # types.anything is intentional: settings are passed through to
+                          # wayland.windowManager.hyprland.settings whose schema is complex
+                          # and validated downstream by the Hyprland home-manager module.
                           settings = lib.mkOption {
                             type = lib.types.attrsOf lib.types.anything;
                             default = { };

--- a/my/users/users/environment-options.nix
+++ b/my/users/users/environment-options.nix
@@ -15,6 +15,9 @@ let
         description = "Application package";
       };
 
+      # types.anything is intentional: settings are passed through to varying
+      # home-manager program modules (programs.firefox, programs.wezterm, etc.)
+      # whose schemas differ per program and are validated downstream.
       settings = lib.mkOption {
         type = lib.types.attrsOf lib.types.anything;
         default = { };


### PR DESCRIPTION
## Summary

- Replaced `types.attrsOf types.anything` in `my/environment/options.nix` (greetd settings) with a typed `types.submodule` containing `default_session.command` (`types.str`) and `default_session.user` (`types.str`), since the implementation only reads those two fields
- Added explanatory comments to the 3 remaining `types.anything` uses in `environment-options.nix`, `apps-options.nix`, and `defaults/default.nix` documenting why `anything` is intentional (they are passthrough attrs forwarded to varying home-manager program modules validated downstream)

## Test plan

- [ ] `nix fmt` passes (verified locally)
- [ ] `statix check .` passes (verified locally)
- [ ] `deadnix --fail .` passes (verified locally)
- [ ] Verify greetd display manager still works with default and custom `command`/`user` values
- [ ] Verify environment app settings passthrough still works (e.g. wezterm, firefox settings)

Closes #47