### PR TITLE
refactor: standardize app module enable check pattern

### DIFF
--- a/my/users/apps/ai/claude-code/default.nix
+++ b/my/users/apps/ai/claude-code/default.nix
@@ -14,7 +14,7 @@ with lib;
           let
             cfg = userCfg.apps.ai.tools.claude-code;
           in
-          mkIf (cfg.enable or false) {
+          mkIf cfg.enable {
             # Use home-manager module for claude-code
             programs.claude-code = {
               enable = true;

--- a/my/users/apps/ai/opencode/default.nix
+++ b/my/users/apps/ai/opencode/default.nix
@@ -9,7 +9,7 @@ with lib;
         let
           cfg = userCfg.apps.ai.tools.opencode;
         in
-        mkIf (cfg.enable or false) {
+        mkIf cfg.enable {
           # Use home-manager module for opencode
           programs.opencode = {
             enable = true;

--- a/my/users/apps/art/mypaint/default.nix
+++ b/my/users/apps/art/mypaint/default.nix
@@ -6,7 +6,7 @@ with lib;
   config = {
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.apps.art.mypaint.enable or false) {
+        mkIf userCfg.apps.art.mypaint.enable {
           home.packages = with pkgs; [
             mypaint
           ];

--- a/my/users/apps/browsers/chromium/default.nix
+++ b/my/users/apps/browsers/chromium/default.nix
@@ -5,7 +5,7 @@ with lib;
 let
   # Check if any user has Chromium enabled
   anyUserChromium = any
-    (userCfg: userCfg.apps.graphical.browsers.chromium.enable or false)
+    (userCfg: userCfg.apps.graphical.browsers.chromium.enable)
     (attrValues config.my.users);
 in
 {
@@ -14,7 +14,7 @@ in
     {
       home-manager.users = mapAttrs
         (_name: userCfg:
-          mkIf (userCfg.apps.graphical.browsers.chromium.enable or false) {
+          mkIf userCfg.apps.graphical.browsers.chromium.enable {
             programs.chromium = {
               enable = true;
             };

--- a/my/users/apps/communication/element/default.nix
+++ b/my/users/apps/communication/element/default.nix
@@ -6,7 +6,7 @@ with lib;
   config = {
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.apps.communication.element.enable or false) {
+        mkIf userCfg.apps.communication.element.enable {
           home.packages = with pkgs; [
             element-desktop
           ];

--- a/my/users/apps/communication/signal/default.nix
+++ b/my/users/apps/communication/signal/default.nix
@@ -6,7 +6,7 @@ with lib;
   config = {
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.apps.communication.signal.enable or false) {
+        mkIf userCfg.apps.communication.signal.enable {
           home.packages = with pkgs; [
             signal-desktop
           ];

--- a/my/users/apps/communication/slack/default.nix
+++ b/my/users/apps/communication/slack/default.nix
@@ -6,7 +6,7 @@ with lib;
   config = {
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.apps.communication.slack.enable or false) {
+        mkIf userCfg.apps.communication.slack.enable {
           home.packages = with pkgs; [
             slack
           ];

--- a/my/users/apps/dev/devenv/default.nix
+++ b/my/users/apps/dev/devenv/default.nix
@@ -6,7 +6,7 @@ with lib;
   config = {
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.apps.dev.tools.devenv.enable or false) {
+        mkIf userCfg.apps.dev.tools.devenv.enable {
           home.packages = with pkgs; [
             devenv
           ];

--- a/my/users/apps/dev/direnv/default.nix
+++ b/my/users/apps/dev/direnv/default.nix
@@ -6,7 +6,7 @@ with lib;
   config = {
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.apps.dev.tools.direnv.enable or false) {
+        mkIf userCfg.apps.dev.tools.direnv.enable {
           programs.direnv = {
             enable = true;
             nix-direnv.enable = true;

--- a/my/users/apps/dev/github-desktop/default.nix
+++ b/my/users/apps/dev/github-desktop/default.nix
@@ -6,7 +6,7 @@ with lib;
   config = {
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.apps.dev.tools.githubDesktop.enable or false) {
+        mkIf userCfg.apps.dev.tools.githubDesktop.enable {
           home.packages = with pkgs; [
             github-desktop
           ];

--- a/my/users/apps/dev/jq/default.nix
+++ b/my/users/apps/dev/jq/default.nix
@@ -6,7 +6,7 @@ with lib;
   config = {
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.apps.dev.tools.jq.enable or false) {
+        mkIf userCfg.apps.dev.tools.jq.enable {
           home.packages = with pkgs; [
             jq
           ];

--- a/my/users/apps/dev/kdiff3/default.nix
+++ b/my/users/apps/dev/kdiff3/default.nix
@@ -6,7 +6,7 @@ with lib;
   config = {
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.apps.dev.tools.kdiff3.enable or false) {
+        mkIf userCfg.apps.dev.tools.kdiff3.enable {
           home.packages = with pkgs; [
             kdiff3
           ];

--- a/my/users/apps/dev/vscode/default.nix
+++ b/my/users/apps/dev/vscode/default.nix
@@ -19,7 +19,7 @@ with lib;
     # Per-user VSCode installation via home-manager
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.apps.dev.tools.vscode.enable or false) {
+        mkIf userCfg.apps.dev.tools.vscode.enable {
           programs.vscode = {
             enable = true;
             package = pkgs.vscode;

--- a/my/users/apps/editors/helix/default.nix
+++ b/my/users/apps/editors/helix/default.nix
@@ -13,7 +13,7 @@ with lib;
         _name: userCfg:
           let
             editor = userCfg.environment.EDITOR;
-            isGraphical = userCfg.graphical.enable or false;
+            isGraphical = userCfg.graphical.enable;
             # Enable helix when:
             # 1. User explicitly set EDITOR to helix, OR
             # 2. User has graphical.enable = true AND didn't set EDITOR (opinionated default)

--- a/my/users/apps/editors/marktext/default.nix
+++ b/my/users/apps/editors/marktext/default.nix
@@ -6,7 +6,7 @@ with lib;
   config = {
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.apps.graphical.editors.marktext.enable or false) {
+        mkIf userCfg.apps.graphical.editors.marktext.enable {
           home.packages = with pkgs; [
             marktext
           ];

--- a/my/users/apps/fileManagers/mc/default.nix
+++ b/my/users/apps/fileManagers/mc/default.nix
@@ -6,7 +6,7 @@ with lib;
   config = {
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.apps.terminal.fileManagers.mc.enable or false) {
+        mkIf userCfg.apps.terminal.fileManagers.mc.enable {
           home.packages = with pkgs; [
             mc
           ];

--- a/my/users/apps/fileUtils/lsd/default.nix
+++ b/my/users/apps/fileUtils/lsd/default.nix
@@ -7,7 +7,7 @@ with lib;
   config = {
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.apps.terminal.fileUtils.lsd.enable or false) {
+        mkIf userCfg.apps.terminal.fileUtils.lsd.enable {
           programs.lsd = {
             enable = true;
             settings = {

--- a/my/users/apps/finance/cointop/default.nix
+++ b/my/users/apps/finance/cointop/default.nix
@@ -6,7 +6,7 @@ with lib;
   config = {
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.apps.finance.cointop.enable or false) {
+        mkIf userCfg.apps.finance.cointop.enable {
           home.packages = with pkgs; [
             cointop
           ];

--- a/my/users/apps/fun/pipes/default.nix
+++ b/my/users/apps/fun/pipes/default.nix
@@ -6,7 +6,7 @@ with lib;
   config = {
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.apps.terminal.fun.pipes.enable or false) {
+        mkIf userCfg.apps.terminal.fun.pipes.enable {
           home.packages = with pkgs; [
             pipes
             neo

--- a/my/users/apps/media/audacious/default.nix
+++ b/my/users/apps/media/audacious/default.nix
@@ -6,7 +6,7 @@ with lib;
   config = {
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.apps.media.audacious.enable or false) {
+        mkIf userCfg.apps.media.audacious.enable {
           home.packages = with pkgs; [
             audacious
           ];

--- a/my/users/apps/media/audio-utils/default.nix
+++ b/my/users/apps/media/audio-utils/default.nix
@@ -6,7 +6,7 @@ with lib;
   config = {
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.apps.media.audioUtils.enable or false) {
+        mkIf userCfg.apps.media.audioUtils.enable {
           home.packages = with pkgs; [
             # Audio utilities
             pavucontrol

--- a/my/users/apps/media/musikcube/default.nix
+++ b/my/users/apps/media/musikcube/default.nix
@@ -6,7 +6,7 @@ with lib;
   config = {
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.apps.media.musikcube.enable or false) {
+        mkIf userCfg.apps.media.musikcube.enable {
           home.packages = with pkgs; [
             musikcube
           ];

--- a/my/users/apps/media/pipewire-tools/default.nix
+++ b/my/users/apps/media/pipewire-tools/default.nix
@@ -6,7 +6,7 @@ with lib;
   config = {
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.apps.media.pipewireTools.enable or false) {
+        mkIf userCfg.apps.media.pipewireTools.enable {
           home.packages = with pkgs; [
             # PipeWire CLI tools
             pipewire

--- a/my/users/apps/multiplexers/zellij/default.nix
+++ b/my/users/apps/multiplexers/zellij/default.nix
@@ -6,7 +6,7 @@ with lib;
   config = {
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.apps.terminal.multiplexers.zellij.enable or false) {
+        mkIf userCfg.apps.terminal.multiplexers.zellij.enable {
           programs.zellij = {
             enable = true;
             enableFishIntegration = false;

--- a/my/users/apps/network/termscp/default.nix
+++ b/my/users/apps/network/termscp/default.nix
@@ -6,7 +6,7 @@ with lib;
   config = {
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.apps.terminal.network.termscp.enable or false) {
+        mkIf userCfg.apps.terminal.network.termscp.enable {
           home.packages = with pkgs; [
             termscp
           ];

--- a/my/users/apps/prompts/starship/default.nix
+++ b/my/users/apps/prompts/starship/default.nix
@@ -6,7 +6,7 @@ with lib;
   config = {
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.apps.terminal.prompts.starship.enable or false) {
+        mkIf userCfg.apps.terminal.prompts.starship.enable {
           programs.starship = {
             enable = true;
             # Load settings from the original TOML file

--- a/my/users/apps/security/1password/default.nix
+++ b/my/users/apps/security/1password/default.nix
@@ -5,7 +5,7 @@ with lib;
 let
   # Check if any user has 1Password enabled
   anyUser1Password = any
-    (userCfg: userCfg.apps.security.onePassword.enable or false)
+    (userCfg: userCfg.apps.security.onePassword.enable)
     (attrValues config.my.users);
 in
 {

--- a/my/users/apps/shells/bash/default.nix
+++ b/my/users/apps/shells/bash/default.nix
@@ -9,7 +9,7 @@ with lib;
         let
           cfg = userCfg.apps.terminal.shells.bash;
         in
-        mkIf (cfg.enable or false) {
+        mkIf cfg.enable {
           programs.bash = {
             enable = true;
             enableCompletion = true;

--- a/my/users/apps/shells/fish/default.nix
+++ b/my/users/apps/shells/fish/default.nix
@@ -6,7 +6,7 @@ with lib;
   config = {
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.apps.terminal.shells.fish.enable or false) {
+        mkIf userCfg.apps.terminal.shells.fish.enable {
           home.packages = with pkgs; [
             # thefuck has been removed, using pay-respects instead
             grc

--- a/my/users/apps/statusbars/waybar/default.nix
+++ b/my/users/apps/statusbars/waybar/default.nix
@@ -6,13 +6,13 @@ with lib;
 
 let
   # Auto-enable when any user has graphical.enable = true
-  anyUserGraphical = any (userCfg: userCfg.graphical.enable or false) (attrValues config.my.users);
+  anyUserGraphical = any (userCfg: userCfg.graphical.enable) (attrValues config.my.users);
 in
 {
   config = mkIf anyUserGraphical {
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.graphical.enable or false) {
+        mkIf userCfg.graphical.enable {
           programs.waybar = {
             enable = true;
 

--- a/my/users/apps/sync/rclone/default.nix
+++ b/my/users/apps/sync/rclone/default.nix
@@ -6,7 +6,7 @@ with lib;
   config = {
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.apps.graphical.sync.rclone.enable or false) {
+        mkIf userCfg.apps.graphical.sync.rclone.enable {
           home.packages = with pkgs; [
             rclone
           ];

--- a/my/users/apps/sysinfo/btop/default.nix
+++ b/my/users/apps/sysinfo/btop/default.nix
@@ -7,7 +7,7 @@ with lib;
   config = {
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.apps.terminal.sysinfo.btop.enable or false) {
+        mkIf userCfg.apps.terminal.sysinfo.btop.enable {
           programs.btop = {
             enable = true;
             settings = {

--- a/my/users/apps/sysinfo/fastfetch/default.nix
+++ b/my/users/apps/sysinfo/fastfetch/default.nix
@@ -20,7 +20,7 @@ in
   config = {
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.apps.terminal.sysinfo.fastfetch.enable or false) {
+        mkIf userCfg.apps.terminal.sysinfo.fastfetch.enable {
           home.packages = with pkgs; [
             fastfetch
           ];

--- a/my/users/apps/sysinfo/neofetch/default.nix
+++ b/my/users/apps/sysinfo/neofetch/default.nix
@@ -7,7 +7,7 @@ with lib;
   config = {
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.apps.terminal.sysinfo.neofetch.enable or false) {
+        mkIf userCfg.apps.terminal.sysinfo.neofetch.enable {
           home.packages = with pkgs; [
             neofetch
             w3m

--- a/my/users/apps/terminals/alacritty/default.nix
+++ b/my/users/apps/terminals/alacritty/default.nix
@@ -6,7 +6,7 @@ with lib;
   config = {
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.apps.graphical.terminals.alacritty.enable or false) {
+        mkIf userCfg.apps.graphical.terminals.alacritty.enable {
           programs.alacritty = {
             enable = true;
           };

--- a/my/users/apps/terminals/ghostty/default.nix
+++ b/my/users/apps/terminals/ghostty/default.nix
@@ -6,7 +6,7 @@ with lib;
   config = {
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.apps.graphical.terminals.ghostty.enable or false) {
+        mkIf userCfg.apps.graphical.terminals.ghostty.enable {
           # Copy shader files from source
           # Note: You'll need to copy the shaders directory from /etc/nixos/home/gui/ghostty/shaders
           # to your theme or config location and adjust the source path below

--- a/my/users/apps/terminals/kitty/default.nix
+++ b/my/users/apps/terminals/kitty/default.nix
@@ -6,7 +6,7 @@ with lib;
   config = {
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.apps.graphical.terminals.kitty.enable or false) {
+        mkIf userCfg.apps.graphical.terminals.kitty.enable {
           programs.kitty = {
             enable = true;
             settings = {

--- a/my/users/apps/terminals/warp/default.nix
+++ b/my/users/apps/terminals/warp/default.nix
@@ -6,7 +6,7 @@ with lib;
   config = {
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.apps.graphical.terminals.warp.enable or false) {
+        mkIf userCfg.apps.graphical.terminals.warp.enable {
           home.packages = with pkgs; [
             warp-terminal
           ];

--- a/my/users/apps/terminals/wezterm/default.nix
+++ b/my/users/apps/terminals/wezterm/default.nix
@@ -8,7 +8,7 @@ with lib;
       (_name: userCfg:
         let
           terminal = userCfg.environment.TERMINAL;
-          isGraphical = userCfg.graphical.enable or false;
+          isGraphical = userCfg.graphical.enable;
           # Enable wezterm when:
           # 1. User explicitly set TERMINAL to wezterm, OR
           # 2. User has graphical.enable = true AND didn't set TERMINAL (opinionated default)

--- a/my/users/apps/utils/calculator/default.nix
+++ b/my/users/apps/utils/calculator/default.nix
@@ -6,7 +6,7 @@ with lib;
   config = {
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.apps.graphical.utils.calculator.enable or false) {
+        mkIf userCfg.apps.graphical.utils.calculator.enable {
           home.packages = with pkgs; [
             qalculate-gtk # Calculator with qalc CLI
           ];

--- a/my/users/apps/utils/imagemagick/default.nix
+++ b/my/users/apps/utils/imagemagick/default.nix
@@ -6,7 +6,7 @@ with lib;
   config = {
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.apps.graphical.utils.imagemagick.enable or false) {
+        mkIf userCfg.apps.graphical.utils.imagemagick.enable {
           home.packages = with pkgs; [
             imagemagick
           ];

--- a/my/users/apps/viewers/bat/default.nix
+++ b/my/users/apps/viewers/bat/default.nix
@@ -7,7 +7,7 @@ with lib;
   config = {
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.apps.terminal.viewers.bat.enable or false) {
+        mkIf userCfg.apps.terminal.viewers.bat.enable {
           programs.bat = {
             enable = true;
           };

--- a/my/users/apps/viewers/feh/default.nix
+++ b/my/users/apps/viewers/feh/default.nix
@@ -6,7 +6,7 @@ with lib;
   config = {
     home-manager.users = mapAttrs
       (_name: userCfg:
-        mkIf (userCfg.apps.terminal.viewers.feh.enable or false) {
+        mkIf userCfg.apps.terminal.viewers.feh.enable {
           home.packages = with pkgs; [
             feh
           ];

--- a/my/users/apps/visualizers/cava/default.nix
+++ b/my/users/apps/visualizers/cava/default.nix
@@ -13,7 +13,7 @@ with lib;
           let
             cfg = userCfg.apps.terminal.visualizers.cava;
           in
-          mkIf (cfg.enable or false) (mkMerge [
+          mkIf cfg.enable (mkMerge [
             {
               programs.cava = {
                 enable = true;
@@ -52,7 +52,7 @@ with lib;
             }
 
             # Enable stylix theming with gradient mode from user config (only if stylix is enabled)
-            (mkIf (config.my.themes.enable or false && config.my.themes.stylix.enable or false) {
+            (mkIf (config.my.themes.enable && config.my.themes.stylix.enable) {
               stylix.targets.cava = {
                 enable = true;
                 inherit (cfg) gradientMode;


### PR DESCRIPTION
## Summary
- Removed unnecessary `or false` defensive checks from all 44 app module enable patterns across `my/users/apps/`
- All app modules now use the direct `mkIf cfg.enable` or `mkIf userCfg.apps.<path>.enable` pattern instead of `mkIf (... or false)`
- Fixed a precedence bug in `cava/default.nix` where `config.my.themes.enable or false && config.my.themes.stylix.enable or false` was incorrectly parsed due to `&&` binding tighter than `or`
- Also removed `or false` from feature-level checks (`graphical.enable`) in helix, wezterm, waybar, and 1password modules where the options have proper defaults

## Test plan
- [ ] Verify `nix flake check` passes
- [ ] Verify `nix fmt -- --check .` passes
- [ ] Verify `statix check .` passes
- [ ] Verify `deadnix --fail .` passes
- [ ] All changes are purely removing redundant `or false` from NixOS options that already have `default = false` defined

Closes #46