### PR TITLE
refactor: add path validation for persistence options

### DIFF
--- a/lib/app-options.nix
+++ b/lib/app-options.nix
@@ -33,12 +33,12 @@
             description = "Persist app data directories and files";
           };
           persistedDirectories = lib.mkOption {
-            type = lib.types.listOf lib.types.str;
+            type = lib.types.listOf lib.types.nonEmptyStr;
             default = persistedDirectories;
             description = "Directories to persist for this app (relative to user home)";
           };
           persistedFiles = lib.mkOption {
-            type = lib.types.listOf lib.types.str;
+            type = lib.types.listOf lib.types.nonEmptyStr;
             default = persistedFiles;
             description = "Files to persist for this app (relative to user home)";
           };

--- a/my/secrets/default.nix
+++ b/my/secrets/default.nix
@@ -7,6 +7,22 @@ let
 in
 {
   config = mkIf cfg.enable {
+    assertions =
+      (optional (cfg.ageKeyFile != null) {
+        assertion = hasPrefix "/" cfg.ageKeyFile;
+        message = "my.secrets.ageKeyFile must be an absolute path, got: ${cfg.ageKeyFile}";
+      })
+      ++ (optional (cfg.gnupgHome != null) {
+        assertion = hasPrefix "/" cfg.gnupgHome;
+        message = "my.secrets.gnupgHome must be an absolute path, got: ${cfg.gnupgHome}";
+      })
+      ++ (map
+        (path: {
+          assertion = hasPrefix "/" path;
+          message = "my.secrets.sshKeyPaths entries must be absolute paths, got: ${path}";
+        })
+        cfg.sshKeyPaths);
+
     # Persistence configuration
     my.system.persistence.features = {
       userDirectories = [

--- a/my/secrets/options.nix
+++ b/my/secrets/options.nix
@@ -11,19 +11,19 @@
     };
 
     sshKeyPaths = lib.mkOption {
-      type = lib.types.listOf lib.types.str;
+      type = lib.types.listOf lib.types.nonEmptyStr;
       default = [ ];
       description = "SSH key paths for sops decryption (age keys derived from SSH)";
     };
 
     gnupgHome = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
+      type = lib.types.nullOr lib.types.nonEmptyStr;
       default = null;
       description = "GnuPG home directory for sops (for GPG/YubiKey decryption)";
     };
 
     ageKeyFile = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
+      type = lib.types.nullOr lib.types.nonEmptyStr;
       default = null;
       description = "Path to age key file for sops decryption";
     };

--- a/my/storage/impermanence/impermanence.nix
+++ b/my/storage/impermanence/impermanence.nix
@@ -23,6 +23,13 @@ let
 in
 {
   config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = hasPrefix "/" persistPath;
+        message = "my.storage.impermanence.persistPath must be an absolute path, got: ${persistPath}";
+      }
+    ];
+
     # Note: Impermanence module is imported separately by the system
 
     # Setup persist filesystem

--- a/my/storage/options.nix
+++ b/my/storage/options.nix
@@ -14,9 +14,9 @@
               enable = lib.mkEnableOption "impermanence with opinionated defaults";
 
               persistPath = lib.mkOption {
-                type = lib.types.str;
+                type = lib.types.nonEmptyStr;
                 default = "/persist";
-                description = "Path to persistent storage directory";
+                description = "Path to persistent storage directory (must be an absolute path)";
               };
 
               useDedicatedPartition = lib.mkOption {
@@ -32,7 +32,7 @@
               };
 
               cloneFlakeRepo = lib.mkOption {
-                type = lib.types.nullOr lib.types.str;
+                type = lib.types.nullOr lib.types.nonEmptyStr;
                 default = null;
                 description = "Git URL to clone into /etc/nixos on first boot";
               };
@@ -44,19 +44,19 @@
               };
 
               extraSystemDirectories = lib.mkOption {
-                type = lib.types.listOf lib.types.str;
+                type = lib.types.listOf lib.types.nonEmptyStr;
                 default = [ ];
                 description = "Additional system directories to persist";
               };
 
               extraUserDirectories = lib.mkOption {
-                type = lib.types.listOf lib.types.str;
+                type = lib.types.listOf lib.types.nonEmptyStr;
                 default = [ ];
                 description = "Additional user directories to persist (applied to all users)";
               };
 
               extraUserFiles = lib.mkOption {
-                type = lib.types.listOf lib.types.str;
+                type = lib.types.listOf lib.types.nonEmptyStr;
                 default = [ ];
                 description = "Additional user files to persist (applied to all users)";
               };

--- a/my/system/options.nix
+++ b/my/system/options.nix
@@ -41,17 +41,17 @@
                 type = lib.types.attrsOf (lib.types.submodule {
                   options = {
                     directories = lib.mkOption {
-                      type = lib.types.listOf lib.types.str;
+                      type = lib.types.listOf lib.types.nonEmptyStr;
                       description = "Aggregated directories to persist for this user";
                       readOnly = true;
                     };
                     files = lib.mkOption {
-                      type = lib.types.listOf lib.types.str;
+                      type = lib.types.listOf lib.types.nonEmptyStr;
                       description = "Aggregated files to persist for this user";
                       readOnly = true;
                     };
                     apps = lib.mkOption {
-                      type = lib.types.listOf lib.types.str;
+                      type = lib.types.listOf lib.types.nonEmptyStr;
                       description = "List of enabled and persisted apps for this user";
                       readOnly = true;
                     };
@@ -65,17 +65,17 @@
                 type = lib.types.submodule {
                   options = {
                     systemDirectories = lib.mkOption {
-                      type = lib.types.listOf lib.types.str;
+                      type = lib.types.listOf lib.types.nonEmptyStr;
                       default = [ ];
                       description = "Aggregated system directories from features";
                     };
                     userDirectories = lib.mkOption {
-                      type = lib.types.listOf lib.types.str;
+                      type = lib.types.listOf lib.types.nonEmptyStr;
                       default = [ ];
                       description = "Aggregated user directories from features (per-user)";
                     };
                     userFiles = lib.mkOption {
-                      type = lib.types.listOf lib.types.str;
+                      type = lib.types.listOf lib.types.nonEmptyStr;
                       default = [ ];
                       description = "Aggregated user files from features (per-user)";
                     };


### PR DESCRIPTION
## Summary

- Change persistence path options (`persistPath`, `extraSystemDirectories`, `extraUserDirectories`, `extraUserFiles`) from `types.str` to `types.nonEmptyStr` to catch empty strings at evaluation time
- Add NixOS assertion that `persistPath` is an absolute path (starts with `/`)
- Add NixOS assertions for secrets paths (`ageKeyFile`, `gnupgHome`, `sshKeyPaths`) to validate they are absolute paths
- Tighten `persistedDirectories` and `persistedFiles` types in `mkAppOption` and system persistence aggregation to `types.nonEmptyStr`
- Change `cloneFlakeRepo` from `types.nullOr types.str` to `types.nullOr types.nonEmptyStr`

## Test plan

- [ ] `nix flake check` passes
- [ ] Existing configs with valid paths continue to work
- [ ] Setting `persistPath = ""` or `persistPath = "relative/path"` produces clear error messages
- [ ] Setting empty strings in `sshKeyPaths` or `extraSystemDirectories` is rejected

Closes #49