### PR TITLE
refactor: standardize feature flag derivation pattern

### DIFF
--- a/my/ai/default.nix
+++ b/my/ai/default.nix
@@ -5,6 +5,9 @@ with lib;
 let
   cfg = config.my.ai;
 
+  # Auto-enable AI when any user has ai.enable = true
+  anyUserAI = any (userCfg: userCfg.ai.enable or false) (attrValues config.my.users);
+
   # mynixos opinionated defaults for AI features
   defaults = {
     mcpServers = false; # MCP servers disabled by default
@@ -52,73 +55,78 @@ let
   };
 in
 {
-  config = mkIf cfg.enable (mkMerge [
-    # Base AI configuration - Ollama with ROCm support (opinionated)
-    {
-      # ROCm packages for AMD GPU acceleration
-      environment.systemPackages = with pkgs; [
-        rocmPackages.rocm-runtime
-        rocmPackages.rocm-device-libs
-        rocmPackages.rocm-smi
-        rocmPackages.hipify
-      ];
+  config = mkMerge [
+    # Set system flag
+    { my.ai.enable = anyUserAI; }
 
-      # Environment variables for ROCm and Ollama
-      environment.variables = {
-        HSA_OVERRIDE_GFX_VERSION = cfg.rocmGfxVersion; # AMD GPU override for ROCm compatibility
-        ROC_ENABLE_PRE_VEGA = "1"; # Enable older AMD GPU support
-        OLLAMA_HOST = "127.0.0.1:11434";
-        OLLAMA_NUM_PARALLEL = "1";
-        OLLAMA_MAX_LOADED_MODELS = "1";
-        OLLAMA_FLASH_ATTENTION = "true";
-      };
-
-      # Ollama service with ROCm acceleration
-      # Uses DynamicUser (nixpkgs default) - do NOT set user/group manually
-      services.ollama = {
-        enable = true;
-        package = pkgs.ollama-rocm; # ROCm acceleration via package selection
-        # user/group intentionally omitted - nixpkgs uses DynamicUser by default
-        home = "/var/lib/ollama";
-        models = "/var/lib/ollama/models";
-        loadModels = [
-          "qwen2.5-coder:32b"
-          "llama3.3:70b"
+    (mkIf cfg.enable (mkMerge [
+      # Base AI configuration - Ollama with ROCm support (opinionated)
+      {
+        # ROCm packages for AMD GPU acceleration
+        environment.systemPackages = with pkgs; [
+          rocmPackages.rocm-runtime
+          rocmPackages.rocm-device-libs
+          rocmPackages.rocm-smi
+          rocmPackages.hipify
         ];
-      };
 
-      # DynamicUser handles user/group automatically - no manual creation needed
+        # Environment variables for ROCm and Ollama
+        environment.variables = {
+          HSA_OVERRIDE_GFX_VERSION = cfg.rocmGfxVersion; # AMD GPU override for ROCm compatibility
+          ROC_ENABLE_PRE_VEGA = "1"; # Enable older AMD GPU support
+          OLLAMA_HOST = "127.0.0.1:11434";
+          OLLAMA_NUM_PARALLEL = "1";
+          OLLAMA_MAX_LOADED_MODELS = "1";
+          OLLAMA_FLASH_ATTENTION = "true";
+        };
 
-      # Override systemd service to add ROCm environment variables
-      systemd.services.ollama.environment = {
-        HSA_OVERRIDE_GFX_VERSION = cfg.rocmGfxVersion;
-        ROC_ENABLE_PRE_VEGA = "1";
-      };
-    }
+        # Ollama service with ROCm acceleration
+        # Uses DynamicUser (nixpkgs default) - do NOT set user/group manually
+        services.ollama = {
+          enable = true;
+          package = pkgs.ollama-rocm; # ROCm acceleration via package selection
+          # user/group intentionally omitted - nixpkgs uses DynamicUser by default
+          home = "/var/lib/ollama";
+          models = "/var/lib/ollama/models";
+          loadModels = [
+            "qwen2.5-coder:32b"
+            "llama3.3:70b"
+          ];
+        };
 
-    # MCP Servers (Model Context Protocol) - per-user configuration
-    {
-      home-manager.users = mapAttrs
-        (_name: userCfg:
-          let
-            # Get user-level AI config (with mynixos opinionated defaults)
-            userAI = userCfg.ai or { };
-          in
-          mkIf (userAI.mcpServers or defaults.mcpServers) {
-            home.packages = lib.attrValues mcp-packages;
-          })
-        config.my.users;
-    }
+        # DynamicUser handles user/group automatically - no manual creation needed
 
-    # Persistence configuration
-    {
-      my.system.persistence.features = {
-        systemDirectories = [
-          # DynamicUser manages /var/lib/private/ollama internally
-          # We persist the parent directory with root ownership
-          "/var/lib/private"
-        ];
-      };
-    }
-  ]);
+        # Override systemd service to add ROCm environment variables
+        systemd.services.ollama.environment = {
+          HSA_OVERRIDE_GFX_VERSION = cfg.rocmGfxVersion;
+          ROC_ENABLE_PRE_VEGA = "1";
+        };
+      }
+
+      # MCP Servers (Model Context Protocol) - per-user configuration
+      {
+        home-manager.users = mapAttrs
+          (_name: userCfg:
+            let
+              # Get user-level AI config (with mynixos opinionated defaults)
+              userAI = userCfg.ai or { };
+            in
+            mkIf (userAI.mcpServers or defaults.mcpServers) {
+              home.packages = lib.attrValues mcp-packages;
+            })
+          config.my.users;
+      }
+
+      # Persistence configuration
+      {
+        my.system.persistence.features = {
+          systemDirectories = [
+            # DynamicUser manages /var/lib/private/ollama internally
+            # We persist the parent directory with root ownership
+            "/var/lib/private"
+          ];
+        };
+      }
+    ]))
+  ];
 }

--- a/my/ai/options.nix
+++ b/my/ai/options.nix
@@ -6,7 +6,11 @@
     default = { };
     type = lib.types.submodule {
       options = {
-        enable = lib.mkEnableOption "AI infrastructure with Ollama and ROCm support";
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Auto-set to true when any user has ai.enable = true (managed by mynixos)";
+        };
 
         rocmGfxVersion = lib.mkOption {
           type = lib.types.str;

--- a/my/dev/development/options.nix
+++ b/my/dev/development/options.nix
@@ -9,7 +9,7 @@
         enable = lib.mkOption {
           type = lib.types.bool;
           default = false;
-          description = "Auto-set to true when any user has dev = true (managed by mynixos)";
+          description = "Auto-set to true when any user has dev.enable = true (managed by mynixos)";
         };
       };
     };

--- a/my/graphical/options.nix
+++ b/my/graphical/options.nix
@@ -9,7 +9,7 @@
         enable = lib.mkOption {
           type = lib.types.bool;
           default = false;
-          description = "Auto-set to true when any user has graphical = true (managed by mynixos)";
+          description = "Auto-set to true when any user has graphical.enable = true (managed by mynixos)";
         };
       };
     };

--- a/my/users/ai/options.nix
+++ b/my/users/ai/options.nix
@@ -9,7 +9,7 @@
         enable = lib.mkOption {
           type = lib.types.bool;
           default = false;
-          description = "Enable AI tools (MCP servers, requires system-level my.features.ai.enable)";
+          description = "Enable AI tools (auto-enables system-level my.ai.enable)";
         };
       };
     };


### PR DESCRIPTION
## Summary

- Add auto-derivation of `my.ai.enable` from user-level `ai.enable` flags, matching the pattern already used by graphical, dev, and streaming features
- Replace `mkEnableOption` with `mkOption` in AI system-level option for consistency with other feature flags
- Fix stale reference to nonexistent `my.features.ai.enable` in user AI option description
- Standardize option descriptions across all system-level feature flags to use consistent `<feature>.enable` wording

## Analysis

Features were investigated and categorized:

| Feature | User flag | System flag | Auto-derived? | Change needed? |
|---------|-----------|-------------|---------------|----------------|
| graphical | `graphical.enable` | `my.graphical.enable` | Yes | Description only |
| dev | `dev.enable` | `my.dev.enable` | Yes | Description only |
| streaming | `graphical.streaming.enable` | `my.streaming.enable` | Yes | None |
| ai | `ai.enable` | `my.ai.enable` | **No** | **Added auto-derivation** |
| terminal | `terminal.enable` | _(none)_ | N/A (user-only) | None needed |
| performance | _(none)_ | `my.performance.enable` | N/A (system-only) | None needed |

The AI feature was the only one with both user-level and system-level flags that lacked auto-derivation, requiring manual `my.ai.enable = true` in system config even when users had `ai.enable = true`.

## Test plan

- [ ] Verify `nix flake check` passes in CI
- [ ] Verify `statix check .` passes in CI
- [ ] Verify `deadnix --fail .` passes in CI
- [ ] Verify that setting `ai.enable = true` on a user auto-enables `my.ai.enable` at the system level
- [ ] Verify that `my.ai.enable` can still be set explicitly to `true` without any user having `ai.enable`

Closes #50