### PR TITLE
refactor: add typed options for common Hyprland settings

### DIFF
--- a/my/graphical/hyprland/default.nix
+++ b/my/graphical/hyprland/default.nix
@@ -25,8 +25,8 @@ let
   '';
 
   # Hyprland configuration modules
-  animations = {
-    enabled = true;
+  mkAnimations = userHyprland: {
+    enabled = userHyprland.animations_enabled;
     bezier = "myBezier, 0.05, 0.9, 0.1, 1.05";
     animation = [
       "windows, 1, 2, myBezier"
@@ -221,22 +221,22 @@ let
 
   # Decoration settings for Hyprland 0.51+
   # blur must be nested under decoration, not at top level
-  decorations = {
-    active_opacity = 1.0;
-    inactive_opacity = 1.0;
+  mkDecorations = userHyprland: {
+    inherit (userHyprland)
+      active_opacity
+      inactive_opacity
+      rounding
+      dim_inactive
+      dim_strength
+      ;
     fullscreen_opacity = 1.0;
-    rounding = 8;
-    dim_inactive = true;
-    dim_strength = 0.3; # 0.0 ~ 1.0
-    # Note: blur is defined here but home-manager may flatten it
-    # See decorationBlur below for workaround
   };
 
   # Separate blur config for explicit nesting
-  decorationBlur = {
-    enabled = true;
+  mkDecorationBlur = userHyprland: {
+    enabled = userHyprland.blur_enabled;
     brightness = 0.7;
-    size = 3;
+    size = userHyprland.blur_size;
   };
 
   environment = {
@@ -246,11 +246,13 @@ let
     env = [ ];
   };
 
-  general = {
-    gaps_in = 10;
-    gaps_out = 10;
-    border_size = 3;
-    layout = "dwindle";
+  mkGeneral = userHyprland: {
+    inherit (userHyprland)
+      gaps_in
+      gaps_out
+      border_size
+      layout
+      ;
   };
 
   group = {
@@ -508,65 +510,73 @@ in
                 xwayland = {
                   enable = true;
                 };
-                settings = {
-                  # General settings - nested under general block
-                  general = {
-                    inherit (general)
-                      gaps_in
-                      gaps_out
-                      border_size
-                      layout
-                      ;
-                  };
+                settings =
+                  let
+                    generalCfg = mkGeneral userHyprland;
+                    decorationsCfg = mkDecorations userHyprland;
+                    blurCfg = mkDecorationBlur userHyprland;
+                    animationsCfg = mkAnimations userHyprland;
+                    baseSettings = {
+                      # General settings - nested under general block
+                      general = {
+                        inherit (generalCfg)
+                          gaps_in
+                          gaps_out
+                          border_size
+                          layout
+                          ;
+                      };
 
-                  # Input settings
-                  input = mkInput userHyprland;
+                      # Input settings
+                      input = mkInput userHyprland;
 
-                  # Layouts
-                  inherit (layouts) dwindle master;
+                      # Layouts
+                      inherit (layouts) dwindle master;
 
-                  # Misc
-                  inherit misc;
+                      # Misc
+                      inherit misc;
 
-                  # Groups
-                  inherit group;
+                      # Groups
+                      inherit group;
 
-                  # Gestures
-                  inherit gestures;
+                      # Gestures
+                      inherit gestures;
 
-                  # Animations
-                  inherit animations;
+                      # Animations
+                      animations = animationsCfg;
 
-                  # Decoration - properly structured for Hyprland 0.51+
-                  # This merges with stylix's decoration settings
-                  decoration = {
-                    inherit (decorations)
-                      active_opacity
-                      inactive_opacity
-                      fullscreen_opacity
-                      rounding
-                      dim_inactive
-                      dim_strength
-                      ;
+                      # Decoration - properly structured for Hyprland 0.51+
+                      # This merges with stylix's decoration settings
+                      decoration = {
+                        inherit (decorationsCfg)
+                          active_opacity
+                          inactive_opacity
+                          fullscreen_opacity
+                          rounding
+                          dim_inactive
+                          dim_strength
+                          ;
 
-                    blur = {
-                      inherit (decorationBlur) enabled brightness size;
-                    };
+                        blur = {
+                          inherit (blurCfg) enabled brightness size;
+                        };
 
-                    # Shadow color managed by stylix theming
-                  };
+                        # Shadow color managed by stylix theming
+                      };
 
-                  # Window and layer rules
-                  inherit layerrule;
-                  windowrule = windowRules;
+                      # Window and layer rules
+                      inherit layerrule;
+                      windowrule = windowRules;
 
-                  # Environment
-                  inherit (environment) monitor env;
+                      # Environment
+                      inherit (environment) monitor;
 
-                  # Autostart
-                  exec-once = autostart;
-                }
-                // (mkBindings { inherit browserCmd terminalCmd; });
+                      # Autostart
+                      exec-once = autostart;
+                    }
+                    // (mkBindings { inherit browserCmd terminalCmd; });
+                  in
+                  lib.recursiveUpdate baseSettings (userHyprland.extraSettings or { });
               };
             }
         ) # End mkIf userHyprland.enable

--- a/my/users/users/apps-options.nix
+++ b/my/users/users/apps-options.nix
@@ -294,10 +294,77 @@ in
                             default = 0.0;
                             description = "Mouse sensitivity (range: -1.0 to 1.0)";
                           };
-                          # types.anything is intentional: settings are passed through to
-                          # wayland.windowManager.hyprland.settings whose schema is complex
-                          # and validated downstream by the Hyprland home-manager module.
-                          settings = lib.mkOption {
+
+                          # General settings
+                          gaps_in = lib.mkOption {
+                            type = lib.types.ints.unsigned;
+                            default = 10;
+                            description = "Inner gaps between windows (pixels)";
+                          };
+                          gaps_out = lib.mkOption {
+                            type = lib.types.ints.unsigned;
+                            default = 10;
+                            description = "Outer gaps between windows and screen edge (pixels)";
+                          };
+                          border_size = lib.mkOption {
+                            type = lib.types.ints.unsigned;
+                            default = 3;
+                            description = "Window border size (pixels)";
+                          };
+                          layout = lib.mkOption {
+                            type = lib.types.enum [ "dwindle" "master" ];
+                            default = "dwindle";
+                            description = "Default tiling layout";
+                          };
+
+                          # Decoration settings
+                          rounding = lib.mkOption {
+                            type = lib.types.ints.unsigned;
+                            default = 8;
+                            description = "Corner rounding radius (pixels)";
+                          };
+                          active_opacity = lib.mkOption {
+                            type = floatBetween 0.0 1.0;
+                            default = 1.0;
+                            description = "Opacity of focused windows (range: 0.0 to 1.0)";
+                          };
+                          inactive_opacity = lib.mkOption {
+                            type = floatBetween 0.0 1.0;
+                            default = 1.0;
+                            description = "Opacity of unfocused windows (range: 0.0 to 1.0)";
+                          };
+                          dim_inactive = lib.mkOption {
+                            type = lib.types.bool;
+                            default = true;
+                            description = "Dim inactive windows";
+                          };
+                          dim_strength = lib.mkOption {
+                            type = floatBetween 0.0 1.0;
+                            default = 0.3;
+                            description = "Dim strength for inactive windows (range: 0.0 to 1.0)";
+                          };
+
+                          # Animation settings
+                          animations_enabled = lib.mkOption {
+                            type = lib.types.bool;
+                            default = true;
+                            description = "Enable window animations";
+                          };
+
+                          # Blur settings
+                          blur_enabled = lib.mkOption {
+                            type = lib.types.bool;
+                            default = true;
+                            description = "Enable background blur";
+                          };
+                          blur_size = lib.mkOption {
+                            type = lib.types.ints.unsigned;
+                            default = 3;
+                            description = "Blur size (intensity)";
+                          };
+
+                          # Escape hatch for advanced config
+                          extraSettings = lib.mkOption {
                             type = lib.types.attrsOf lib.types.anything;
                             default = { };
                             description = "Additional Hyprland settings (passthrough to wayland.windowManager.hyprland.settings)";


### PR DESCRIPTION
## Summary
- Replace the untyped `settings` passthrough attribute on the Hyprland app option with strongly-typed options for the most commonly configured Hyprland settings: `gaps_in`, `gaps_out`, `border_size`, `rounding`, `layout`, `active_opacity`, `inactive_opacity`, `dim_inactive`, `dim_strength`, `animations_enabled`, `blur_enabled`, and `blur_size`
- Preserve an `extraSettings` escape hatch (`attrsOf anything`) for advanced users who need to pass arbitrary Hyprland config
- Update the Hyprland implementation to derive all settings from the typed user options instead of hardcoded values
- Fix a latent bug where `inherit (environment) monitor env` referenced a non-existent `env` attribute

## Test plan
- [ ] Verify `nix flake check` passes
- [ ] Verify `nix fmt -- --check .` passes
- [ ] Verify `statix check .` passes
- [ ] Verify `deadnix --fail .` passes
- [ ] Test that a system config using default Hyprland settings evaluates correctly
- [ ] Test that overriding typed options (e.g., `gaps_in = 5`) is reflected in Hyprland config
- [ ] Test that `extraSettings` merges additional attributes into the Hyprland settings

Closes #48