### PR TITLE
ci: add module coverage tracking with Codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%

--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -48,10 +48,31 @@ jobs:
         run: nix run nixpkgs#statix -- check .
       - name: Run deadnix
         run: nix run nixpkgs#deadnix -- --fail .
+  module-coverage:
+    name: Module Coverage
+    runs-on: ubuntu-latest
+    needs: [nix-flake-check]
+    if: |
+      !(
+        (github.event_name == 'pull_request' && startsWith(github.event.pull_request.title, 'chore(master): release')) ||
+        (github.event_name == 'push' && contains(github.event.head_commit.message, 'release-please--branches--master'))
+      )
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Generate module coverage report
+        run: bash scripts/module-coverage.sh --lcov
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.lcov
+          flags: modules
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
-    needs: [nix-flake-check, nix-lint]
+    needs: [nix-flake-check, nix-lint, module-coverage]
     # always() prevents auto-skip when dependencies are skipped (release merges)
     # Then check: either CI passed or was skipped (release-please commits skip CI)
     if: |

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ CLAUDE.md
 # Build artifacts
 result
 result-*
+coverage.lcov
 
 # Nix
 .direnv/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![CI and Release](https://github.com/i-am-logger/mynixos/actions/workflows/ci-and-release.yml/badge.svg)](https://github.com/i-am-logger/mynixos/actions/workflows/ci-and-release.yml)
+[![Module Coverage](https://codecov.io/gh/i-am-logger/mynixos/graph/badge.svg)](https://codecov.io/gh/i-am-logger/mynixos)
 [![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by-nc-sa/4.0/)
 [![NixOS](https://img.shields.io/badge/NixOS-5277C3?logo=nixos&logoColor=white)](https://nixos.org)
 [![Release](https://img.shields.io/github/v/release/i-am-logger/mynixos)](https://github.com/i-am-logger/mynixos/releases)

--- a/scripts/module-coverage.sh
+++ b/scripts/module-coverage.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# module-coverage.sh - Track module coverage for mynixos
+#
+# Counts modules imported in flake.nix and cross-references with
+# checks/tests to produce a coverage percentage. For NixOS module
+# projects, "coverage" means: which modules are exercised by the
+# flake checks (nix flake check evaluates all imports).
+#
+# Output: coverage summary + optional LCOV-style report for badge generation.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Extract all module paths imported in flake.nix (./my/ paths)
+extract_imported_modules() {
+  grep -oP '\./my/[a-zA-Z0-9_./-]+' "$REPO_ROOT/flake.nix" |
+    sed 's|^\./||' |
+    sort -u
+}
+
+# Count unique module directories (each directory = one module)
+count_module_dirs() {
+  local modules
+  modules=$(extract_imported_modules)
+  echo "$modules" | sed 's|/[^/]*\.nix$||' | sort -u | wc -l
+}
+
+# All modules are evaluated by `nix flake check` because:
+# - flake.nix imports every module in nixosModules.default
+# - `nix flake check` evaluates the flake outputs including the module
+# - The checks (formatting, pre-commit) exercise the full module tree
+#
+# So coverage = modules checked by flake evaluation / total modules.
+# Modules NOT covered would be any .nix files under my/ that are NOT
+# imported in flake.nix.
+
+# Find module directories under my/ that exist but are NOT imported in flake.nix
+find_unimported_modules() {
+  local imported
+  imported=$(extract_imported_modules | sed 's|/[^/]*\.nix$||' | sort -u)
+
+  # Find all directories under my/ that contain a default.nix or options.nix
+  local all_module_dirs
+  all_module_dirs=$(find "$REPO_ROOT/my" -name "default.nix" -o -name "options.nix" |
+    sed "s|$REPO_ROOT/||" |
+    sed 's|/[^/]*\.nix$||' |
+    sort -u)
+
+  # Exclude internal subdirectories that are imported as part of their parent
+  comm -23 <(echo "$all_module_dirs") <(echo "$imported")
+}
+
+# Generate coverage report
+generate_report() {
+  local total_modules imported_count unimported_count coverage_pct
+  local imported unimported
+
+  imported=$(extract_imported_modules | sed 's|/[^/]*\.nix$||' | sort -u)
+  imported_count=$(echo "$imported" | wc -l)
+
+  unimported=$(find_unimported_modules)
+  if [ -z "$unimported" ]; then
+    unimported_count=0
+  else
+    unimported_count=$(echo "$unimported" | wc -l)
+  fi
+
+  total_modules=$((imported_count + unimported_count))
+
+  if [ "$total_modules" -eq 0 ]; then
+    coverage_pct=0
+  else
+    coverage_pct=$((imported_count * 100 / total_modules))
+  fi
+
+  echo "=== mynixos Module Coverage Report ==="
+  echo ""
+  echo "Total module directories: $total_modules"
+  echo "Imported in flake.nix:    $imported_count"
+  echo "Not imported:             $unimported_count"
+  echo "Coverage:                 ${coverage_pct}%"
+  echo ""
+
+  if [ "$unimported_count" -gt 0 ]; then
+    echo "Unimported modules:"
+    while IFS= read -r line; do
+      echo "  - $line"
+    done <<<"$unimported"
+    echo ""
+  fi
+
+  # Output for CI badge generation
+  if [ "${1:-}" = "--json" ]; then
+    cat <<EOJSON
+{"total": $total_modules, "covered": $imported_count, "uncovered": $unimported_count, "percentage": $coverage_pct}
+EOJSON
+  fi
+
+  # Generate LCOV-style output for potential Codecov integration
+  if [ "${1:-}" = "--lcov" ]; then
+    local lcov_file="$REPO_ROOT/coverage.lcov"
+    : >"$lcov_file"
+    while IFS= read -r mod; do
+      local mod_file="$REPO_ROOT/$mod/default.nix"
+      if [ ! -f "$mod_file" ]; then
+        mod_file=$(find "$REPO_ROOT/$mod" -name "*.nix" -maxdepth 1 | head -1)
+      fi
+      if [ -n "$mod_file" ] && [ -f "$mod_file" ]; then
+        local line_count
+        line_count=$(wc -l <"$mod_file")
+        {
+          local rel_path="${mod_file#"$REPO_ROOT"/}"
+          echo "SF:$rel_path"
+          for i in $(seq 1 "$line_count"); do
+            echo "DA:$i,1"
+          done
+          echo "LF:$line_count"
+          echo "LH:$line_count"
+          echo "end_of_record"
+        } >>"$lcov_file"
+      fi
+    done <<<"$imported"
+
+    # Mark unimported modules as uncovered
+    if [ -n "$unimported" ]; then
+      while IFS= read -r mod; do
+        local mod_file="$REPO_ROOT/$mod/default.nix"
+        if [ ! -f "$mod_file" ]; then
+          mod_file=$(find "$REPO_ROOT/$mod" -name "*.nix" -maxdepth 1 | head -1)
+        fi
+        if [ -n "$mod_file" ] && [ -f "$mod_file" ]; then
+          local line_count
+          line_count=$(wc -l <"$mod_file")
+          {
+            local rel_path="${mod_file#"$REPO_ROOT"/}"
+            echo "SF:$rel_path"
+            for i in $(seq 1 "$line_count"); do
+              echo "DA:$i,0"
+            done
+            echo "LF:$line_count"
+            echo "LH:0"
+            echo "end_of_record"
+          } >>"$lcov_file"
+        fi
+      done <<<"$unimported"
+    fi
+
+    echo "LCOV report written to $lcov_file"
+  fi
+
+  return 0
+}
+
+generate_report "${1:-}"


### PR DESCRIPTION
## Summary
- Add `scripts/module-coverage.sh` that tracks which `my/` module directories are imported in `flake.nix` vs total modules on disk, producing a coverage percentage and LCOV report
- Add `module-coverage` CI job that generates LCOV coverage data after `nix flake check` passes and uploads to Codecov
- Add `.codecov.yml` with project status config (auto target, 5% threshold)
- Add Codecov badge to README.md

Current module coverage: **95%** (109/114 module directories imported in flake.nix)

## How it works
For NixOS module projects, traditional code coverage tools don't apply. Instead, this tracks "module coverage" - which module directories under `my/` are actually imported and evaluated by `flake.nix`. Since `nix flake check` evaluates the full flake including `nixosModules.default`, every imported module is exercised during CI. Unimported modules (e.g. `my/themes/stylix`, `my/themes/vogix`) represent code that exists but isn't wired into the module system.

The script generates standard LCOV output where imported modules have all lines marked as covered and unimported modules have all lines marked as uncovered, which Codecov can parse.

## Test plan
- [x] `scripts/module-coverage.sh` runs locally and reports 95% coverage
- [x] `scripts/module-coverage.sh --lcov` generates valid LCOV with relative paths
- [x] `scripts/module-coverage.sh --json` outputs machine-readable summary
- [x] `nix fmt` passes
- [x] `statix check .` passes
- [x] `deadnix --fail .` passes

Closes #53