### PR TITLE
refactor: add browser dependency guard for webapps

### DIFF
--- a/my/users/webapps/default.nix
+++ b/my/users/webapps/default.nix
@@ -11,6 +11,13 @@ let
   anyUserSignal = any (userCfg: (userCfg.graphical.webapps.signal or false)) (attrValues config.my.users);
   anyUser1Password = any (userCfg: (userCfg.graphical.webapps.onePassword or false)) (attrValues config.my.users);
 
+  # Users who have webapps enabled but not graphical
+  usersWithWebappsNoGraphical = filter
+    (name:
+      let userCfg = config.my.users.${name};
+      in (userCfg.graphical.webapps.enable or false) && !(userCfg.graphical.enable or false))
+    (attrNames config.my.users);
+
   # mynixos opinionated defaults for webapps
   defaults = {
     # Browser-based webapps
@@ -67,6 +74,19 @@ let
 in
 {
   config = mkIf anyUserWebapps (mkMerge [
+    # Browser dependency guard: webapps require a graphical environment because
+    # browser-based PWAs are rendered via Chromium (bundled with Widevine for DRM).
+    # The module provisions its own Chromium instance, so users do not need to
+    # explicitly enable apps.graphical.browsers.chromium.
+    {
+      assertions = map
+        (name: {
+          assertion = false;
+          message = "my.users.${name}.graphical.webapps.enable requires graphical.enable = true. Webapps are browser-based PWAs that need a graphical environment (Chromium is used as the rendering engine).";
+        })
+        usersWithWebappsNoGraphical;
+    }
+
     # Allow unfree packages for webapps (chromium, widevine, etc.)
     {
       my.system.allowedUnfreePackages = [


### PR DESCRIPTION
## Summary
- Add NixOS assertion to the webapps module that validates `graphical.enable = true` when `graphical.webapps.enable = true`, producing a clear error message naming the offending user
- Document the Chromium dependency relationship in comments: webapps provision their own Chromium+Widevine instance, so users do not need to separately enable the browser module

## Test plan
- [ ] Verify `nix flake check` passes
- [ ] Verify a config with `graphical.webapps.enable = true` but `graphical.enable = false` produces the assertion error
- [ ] Verify existing configs with both `graphical.enable = true` and `graphical.webapps.enable = true` continue to work

Closes #52