### PR TITLE
fix: remove pkgs from option-definition time to prevent infinite recursion

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -145,13 +145,15 @@
       # Main NixOS module providing the `my.*` namespace
       nixosModules.default =
         { lib
-        , pkgs
         , ...
         }:
         let
-          # Use module's own pkgs when available, ensuring correct pkgs scope
-          mkOptionsModule = path: args: { pkgs ? args.pkgs or null, ... }:
-            { options.my = import path (args // lib.optionalAttrs (pkgs != null) { inherit pkgs; }); };
+          # Import options modules - args are passed through directly.
+          # Do NOT capture `pkgs` from module function args here, as that
+          # triggers _module.args.pkgs evaluation which depends on config.nixpkgs,
+          # causing infinite recursion when hardware modules set nixpkgs.hostPlatform.
+          mkOptionsModule = path: args: _:
+            { options.my = import path args; };
         in
         {
           config = {
@@ -365,16 +367,16 @@
           # Option definitions
           ++ [
             # Top-level options
-            (mkOptionsModule ./my/system/options.nix { inherit lib pkgs; })
+            (mkOptionsModule ./my/system/options.nix { inherit lib; })
             (mkOptionsModule ./my/security/options.nix { inherit lib; })
-            (mkOptionsModule ./my/environment/options.nix { inherit lib pkgs; })
+            (mkOptionsModule ./my/environment/options.nix { inherit lib; })
             (mkOptionsModule ./my/performance/options.nix { inherit lib; })
             (mkOptionsModule ./my/graphical/options.nix { inherit lib; })
             (mkOptionsModule ./my/dev/development/options.nix { inherit lib; })
             (mkOptionsModule ./my/streaming/options.nix { inherit lib; })
             (mkOptionsModule ./my/ai/options.nix { inherit lib; })
             (mkOptionsModule ./my/video/virtual/options.nix { inherit lib; })
-            (mkOptionsModule ./my/themes/options.nix { inherit lib pkgs; })
+            (mkOptionsModule ./my/themes/options.nix { inherit lib; })
 
             # Category-level options
             (mkOptionsModule ./my/infra/options.nix { inherit lib; })
@@ -387,13 +389,14 @@
             (mkOptionsModule ./my/filesystem-options.nix { inherit lib; })
 
             # Users options
-            (mkOptionsModule ./my/users/users/options.nix { inherit lib pkgs; })
+            (mkOptionsModule ./my/users/users/options.nix { inherit lib; })
 
             # Users opinionated defaults (mynixos.nix files)
             ./my/users/terminal/mynixos.nix
             ./my/users/graphical/mynixos.nix
             ./my/users/dev/mynixos.nix
             ./my/users/ai/mynixos.nix
+            ./my/users/environment/mynixos.nix
             ./my/users/themes/vogix/mynixos.nix
 
             # Secrets (special - uses different pattern)

--- a/my/ai/default.nix
+++ b/my/ai/default.nix
@@ -56,8 +56,8 @@ let
 in
 {
   config = mkMerge [
-    # Set system flag
-    { my.ai.enable = anyUserAI; }
+    # Auto-derive system AI flag from user config (overridable)
+    { my.ai.enable = mkDefault anyUserAI; }
 
     (mkIf cfg.enable (mkMerge [
       # Base AI configuration - Ollama with ROCm support (opinionated)

--- a/my/environment/default.nix
+++ b/my/environment/default.nix
@@ -1,10 +1,12 @@
-{ config, lib, ... }:
+{ config, lib, pkgs, ... }:
 
 with lib;
 
 let
   cfg = config.my.environment;
   motdCfg = cfg.motd;
+  editor = if cfg.editor != null then cfg.editor else pkgs.helix;
+  browser = if cfg.browser != null then cfg.browser else pkgs.brave;
 in
 {
   config = mkMerge [
@@ -34,24 +36,27 @@ in
         # Note: BROWSER needs full path to binary for XDG to work correctly
         environment = {
           variables = {
-            EDITOR = "${cfg.editor}/bin/hx";
-            VIEWER = "${cfg.editor}/bin/hx";
-            BROWSER = "${cfg.browser}/bin/${cfg.browser.pname or "brave"}";
-            DEFAULT_BROWSER = "${cfg.browser}/bin/${cfg.browser.pname or "brave"}";
+            EDITOR = "${editor}/bin/${editor.meta.mainProgram or editor.pname or "hx"}";
+            VIEWER = "${editor}/bin/${editor.meta.mainProgram or editor.pname or "hx"}";
+            BROWSER = "${browser}/bin/${browser.meta.mainProgram or browser.pname or "brave"}";
+            DEFAULT_BROWSER = "${browser}/bin/${browser.meta.mainProgram or browser.pname or "brave"}";
           };
 
           pathsToLink = [ "libexec" ];
-          sessionVariables.DEFAULT_BROWSER = mkDefault "${cfg.browser}/bin/${cfg.browser.pname or "brave"}";
+          sessionVariables.DEFAULT_BROWSER = mkDefault "${browser}/bin/${browser.meta.mainProgram or browser.pname or "brave"}";
         };
 
         # XDG MIME defaults - using .desktop file pattern
-        xdg.mime.defaultApplications = mkDefault {
-          "text/html" = "${cfg.browser.pname or "brave"}-browser.desktop";
-          "x-scheme-handler/http" = "${cfg.browser.pname or "brave"}-browser.desktop";
-          "x-scheme-handler/https" = "${cfg.browser.pname or "brave"}-browser.desktop";
-          "x-scheme-handler/about" = "${cfg.browser.pname or "brave"}-browser.desktop";
-          "x-scheme-handler/unknown" = "${cfg.browser.pname or "brave"}-browser.desktop";
-        };
+        xdg.mime.defaultApplications =
+          let browserDesktop = "${browser.pname or "brave"}-browser.desktop";
+          in
+          mkDefault {
+            "text/html" = browserDesktop;
+            "x-scheme-handler/http" = browserDesktop;
+            "x-scheme-handler/https" = browserDesktop;
+            "x-scheme-handler/about" = browserDesktop;
+            "x-scheme-handler/unknown" = browserDesktop;
+          };
       }
 
       # Common environment configuration (always enabled with environment feature)

--- a/my/environment/options.nix
+++ b/my/environment/options.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs, ... }:
+{ lib, ... }:
 
 {
   environment = lib.mkOption {
@@ -9,15 +9,15 @@
         enable = lib.mkEnableOption "environment configuration (variables, XDG, locale)";
 
         editor = lib.mkOption {
-          type = lib.types.package;
-          default = pkgs.helix;
-          description = "Default text editor package (mynixos default: helix)";
+          type = lib.types.nullOr lib.types.package;
+          default = null;
+          description = "Default text editor package (mynixos default: helix). Null means use the mynixos default.";
         };
 
         browser = lib.mkOption {
-          type = lib.types.package;
-          default = pkgs.brave;
-          description = "Default web browser package (mynixos default: brave)";
+          type = lib.types.nullOr lib.types.package;
+          default = null;
+          description = "Default web browser package (mynixos default: brave). Null means use the mynixos default.";
         };
 
         displayManager = lib.mkOption {

--- a/my/hardware/gpu/nvidia/default.nix
+++ b/my/hardware/gpu/nvidia/default.nix
@@ -7,6 +7,35 @@ let
 in
 {
   config = mkIf (cfg == "nvidia") {
+    # Allow NVIDIA unfree packages
+    my.system.allowedUnfreePackages = [
+      "nvidia-x11"
+      "nvidia-settings"
+      "nvidia-persistenced"
+      "cudatoolkit"
+      "cuda_cccl"
+      "cuda_cudart"
+      "cuda_cuobjdump"
+      "cuda_cupti"
+      "cuda_cuxxfilt"
+      "cuda_gdb"
+      "cuda_nvcc"
+      "cuda_nvdisasm"
+      "cuda_nvml_dev"
+      "cuda_nvprune"
+      "cuda_nvrtc"
+      "cuda_nvtx"
+      "cuda_profiler_api"
+      "cuda_sanitizer_api"
+      "libcublas"
+      "libcufft"
+      "libcurand"
+      "libcusolver"
+      "libcusparse"
+      "libnpp"
+      "libnvjitlink"
+    ];
+
     # NVIDIA GPU driver configuration
     hardware.graphics = {
       enable = true;

--- a/my/themes/options.nix
+++ b/my/themes/options.nix
@@ -1,6 +1,6 @@
 # Unified themes options
 # Defines my.themes.* with stylix and vogix as submodules
-{ lib, pkgs, ... }:
+{ lib, ... }:
 
 let
   inherit (import ../../lib/app-options.nix { inherit lib; }) floatBetween;
@@ -143,9 +143,9 @@ in
                             description = "Serif font name";
                           };
                           package = lib.mkOption {
-                            type = lib.types.package;
-                            default = pkgs.nerd-fonts.noto;
-                            description = "Serif font package";
+                            type = lib.types.nullOr lib.types.package;
+                            default = null;
+                            description = "Serif font package (default: nerd-fonts.noto)";
                           };
                         };
                       };
@@ -162,9 +162,9 @@ in
                             description = "Sans-serif font name";
                           };
                           package = lib.mkOption {
-                            type = lib.types.package;
-                            default = pkgs.nerd-fonts.fira-code;
-                            description = "Sans-serif font package";
+                            type = lib.types.nullOr lib.types.package;
+                            default = null;
+                            description = "Sans-serif font package (default: nerd-fonts.fira-code)";
                           };
                         };
                       };
@@ -181,9 +181,9 @@ in
                             description = "Monospace font name";
                           };
                           package = lib.mkOption {
-                            type = lib.types.package;
-                            default = pkgs.nerd-fonts.fira-code;
-                            description = "Monospace font package";
+                            type = lib.types.nullOr lib.types.package;
+                            default = null;
+                            description = "Monospace font package (default: nerd-fonts.fira-code)";
                           };
                         };
                       };
@@ -200,9 +200,9 @@ in
                             description = "Emoji font name";
                           };
                           package = lib.mkOption {
-                            type = lib.types.package;
-                            default = pkgs.noto-fonts-color-emoji;
-                            description = "Emoji font package";
+                            type = lib.types.nullOr lib.types.package;
+                            default = null;
+                            description = "Emoji font package (default: noto-fonts-color-emoji)";
                           };
                         };
                       };
@@ -224,9 +224,9 @@ in
                       description = "Cursor theme name";
                     };
                     package = lib.mkOption {
-                      type = lib.types.package;
-                      default = pkgs.bibata-cursors;
-                      description = "Cursor theme package";
+                      type = lib.types.nullOr lib.types.package;
+                      default = null;
+                      description = "Cursor theme package (default: bibata-cursors)";
                     };
                     size = lib.mkOption {
                       type = lib.types.int;

--- a/my/users/apps/ai/claude-code/default.nix
+++ b/my/users/apps/ai/claude-code/default.nix
@@ -6,25 +6,34 @@
 
 with lib;
 
+let
+  anyUserClaudeCode = any
+    (userCfg: userCfg.apps.ai.tools.claude-code.enable or false)
+    (attrValues config.my.users);
+in
 {
-  config = {
-    home-manager.users = mapAttrs
-      (
-        _name: userCfg:
-          let
-            cfg = userCfg.apps.ai.tools.claude-code;
-          in
-          mkIf cfg.enable {
-            # Use home-manager module for claude-code
-            programs.claude-code = {
-              enable = true;
-              package = pkgs.claude-code;
-            };
+  config = mkMerge [
+    # Allow claude-code unfree package (when ANY user enables it)
+    (mkIf anyUserClaudeCode {
+      my.system.allowedUnfreePackages = [ "claude-code" ];
+    })
 
-            # Claude Code persists its data in ~/.claude
-            # This is handled by the app's persistedDirectories in options/users/apps.nix
-          }
-      )
-      config.my.users;
-  };
+    # Per-user claude-code installation via home-manager
+    {
+      home-manager.users = mapAttrs
+        (
+          _name: userCfg:
+            let
+              cfg = userCfg.apps.ai.tools.claude-code;
+            in
+            mkIf cfg.enable {
+              programs.claude-code = {
+                enable = true;
+                package = pkgs.claude-code;
+              };
+            }
+        )
+        config.my.users;
+    }
+  ];
 }

--- a/my/users/apps/communication/slack/default.nix
+++ b/my/users/apps/communication/slack/default.nix
@@ -2,15 +2,27 @@
 
 with lib;
 
+let
+  anyUserSlack = any
+    (userCfg: userCfg.apps.communication.messaging.slack.enable or false)
+    (attrValues config.my.users);
+in
 {
-  config = {
-    home-manager.users = mapAttrs
-      (_name: userCfg:
-        mkIf userCfg.apps.communication.messaging.slack.enable or false {
-          home.packages = with pkgs; [
-            slack
-          ];
-        })
-      config.my.users;
-  };
+  config = mkMerge [
+    # Allow slack unfree package (when ANY user enables it)
+    (mkIf anyUserSlack {
+      my.system.allowedUnfreePackages = [ "slack" ];
+    })
+
+    {
+      home-manager.users = mapAttrs
+        (_name: userCfg:
+          mkIf (userCfg.apps.communication.messaging.slack.enable or false) {
+            home.packages = with pkgs; [
+              slack
+            ];
+          })
+        config.my.users;
+    }
+  ];
 }

--- a/my/users/apps/editors/helix/default.nix
+++ b/my/users/apps/editors/helix/default.nix
@@ -6,372 +6,380 @@
 
 with lib;
 
+let
+  # Use the dedicated app option instead of inspecting environment.EDITOR.
+  # Checking environment.EDITOR would trigger pkgs evaluation and infinite
+  # recursion when hardware modules set nixpkgs.hostPlatform.
+  # The app option is set mkDefault true by graphical/mynixos.nix for
+  # graphical users and can be explicitly enabled by non-graphical users.
+  anyUserHelix = any
+    (userCfg: userCfg.apps.graphical.editors.helix.enable or false)
+    (attrValues config.my.users);
+in
 {
-  config = {
-    home-manager.users = mapAttrs
-      (
-        _name: userCfg:
-          let
-            editor = userCfg.environment.EDITOR;
-            isGraphical = userCfg.graphical.enable;
-            # Enable helix when:
-            # 1. User explicitly set EDITOR to helix, OR
-            # 2. User has graphical.enable = true AND didn't set EDITOR (opinionated default)
-            hasHelix =
-              if editor != null then editor.enable && (editor.package.pname or "") == "helix" else isGraphical; # Opinionated default: helix when graphical enabled and no editor specified
-          in
-          mkIf hasHelix {
-            home.packages = with pkgs; [
-              helix
-              alejandra
+  config = mkMerge [
+    # Allow github-copilot-cli unfree package (when ANY user has helix)
+    (mkIf anyUserHelix {
+      my.system.allowedUnfreePackages = [ "github-copilot-cli" ];
+    })
 
-              # pkgs.nodePackages.bash-language-server
-              cmake-language-server
-              marksman
-              markdown-oxide
+    {
+      home-manager.users = mapAttrs
+        (
+          _name: userCfg:
+            mkIf (userCfg.apps.graphical.editors.helix.enable or false) {
+              home.packages = with pkgs; [
+                helix
+                alejandra
 
-              # zellij
-              # lazygit
-              nil
-              # pkgs.rnix-lsp
-              rust-analyzer
-              lldb
-              clang-tools
-              # ocamlPackages.ocaml-lsp
-              vscode-langservers-extracted
-              # dockerfile-language-server-nodejs
-              # haskellPackages.haskell-language-server
-              # nodePackages.typescript-language-server
-              texlab
-              # lua-language-server
-              # marksman
-              # pkgs.nodePackages.pyright
-              # pkgs.python310Packages.python-lsp-server
-              # nodePackages.vue-language-server
-              yaml-language-server
-              taplo
-              github-copilot-cli
-              # pkgs.vimPlugins.copilot-vim
-              tree-sitter
-              (tree-sitter.withPlugins (_: tree-sitter.allGrammars))
-              # nixpkgs-fmt
-              # nixfmt
-              nixfmt
-              # nixpkgs-fmt
-            ];
+                # pkgs.nodePackages.bash-language-server
+                cmake-language-server
+                marksman
+                markdown-oxide
 
-            programs.helix = {
-              enable = true;
-              defaultEditor = true;
-              settings = {
-                editor = {
-                  # line-number = "relative";
-                  rulers = [ 120 ];
-                  bufferline = "always";
-                  mouse = true;
-                  true-color = true;
-                  color-modes = true;
-                  cursorline = true;
-                  auto-completion = true;
-                  completion-trigger-len = 1;
+                # zellij
+                # lazygit
+                nil
+                # pkgs.rnix-lsp
+                rust-analyzer
+                lldb
+                clang-tools
+                # ocamlPackages.ocaml-lsp
+                vscode-langservers-extracted
+                # dockerfile-language-server-nodejs
+                # haskellPackages.haskell-language-server
+                # nodePackages.typescript-language-server
+                texlab
+                # lua-language-server
+                # marksman
+                # pkgs.nodePackages.pyright
+                # pkgs.python310Packages.python-lsp-server
+                # nodePackages.vue-language-server
+                yaml-language-server
+                taplo
+                github-copilot-cli
+                # pkgs.vimPlugins.copilot-vim
+                tree-sitter
+                (tree-sitter.withPlugins (_: tree-sitter.allGrammars))
+                # nixpkgs-fmt
+                # nixfmt
+                nixfmt
+                # nixpkgs-fmt
+              ];
 
-                  end-of-line-diagnostics = "hint";
-                  inline-diagnostics = {
-                    cursor-line = "error";
-                  };
-                  cursor-shape = {
-                    insert = "bar";
-                    normal = "block";
-                    select = "underline";
-                  };
-                  file-picker = {
-                    hidden = false;
-                    git-ignore = true;
-                  };
-                  soft-wrap = {
-                    enable = true;
-                  };
-                  statusline = {
-                    left = [
-                      "mode"
-                      "file-name"
-                      "spinner"
-                    ];
-                    center = [ "position-percentage" ];
-                    right = [
-                      "version-control"
-                      "diagnostics"
-                      "selections"
-                      "position"
-                      "file-encoding"
-                      "file-line-ending"
-                      "file-type"
-                    ];
-                    separator = "│";
-                  };
-                  lsp = {
-                    enable = true;
-                    display-messages = true;
-                    auto-signature-help = true;
-                    # display-inlay-hints = true;
-                    display-signature-help-docs = true;
-                    snippets = true;
-                    goto-reference-include-declaration = true;
-                  };
-                  whitespace = {
-                    render = "all";
-                    characters = {
-                      space = " ";
-                      nbsp = "⍽";
-                      tab = "→";
-                      # newline = "⏎";
-                      tabpad = " "; # "·"; # Tabs will look like "→···" (depending on tab width)
+              programs.helix = {
+                enable = true;
+                defaultEditor = true;
+                settings = {
+                  editor = {
+                    # line-number = "relative";
+                    rulers = [ 120 ];
+                    bufferline = "always";
+                    mouse = true;
+                    true-color = true;
+                    color-modes = true;
+                    cursorline = true;
+                    auto-completion = true;
+                    completion-trigger-len = 1;
+
+                    end-of-line-diagnostics = "hint";
+                    inline-diagnostics = {
+                      cursor-line = "error";
                     };
-                  };
-                  indent-guides = {
-                    render = true;
-                    character = "│"; # "╎";
-                  };
-                };
-                keys.normal = {
-                  esc = [
-                    "collapse_selection"
-                    "keep_primary_selection"
-                  ];
-                  J = [
-                    "delete_selection"
-                    "paste_after"
-                  ];
-                  K = [
-                    "delete_selection"
-                    "move_line_up"
-                    "paste_before"
-                  ];
-                  C-u = [
-                    "half_page_up"
-                    "align_view_center"
-                  ];
-                  C-d = [
-                    "half_page_down"
-                    "align_view_center"
-                  ];
-
-                  "[" = "goto_previous_buffer";
-                  "]" = "goto_next_buffer";
-
-                  g = {
-                    x = ":buffer-close";
-                    j = "jump_backward";
-                    k = "jump_forward";
-                  };
-                  space = {
-                    l = ":toggle lsp.display-inlay-hints";
-                    n = ":toggle lsp.auto-signature_help";
-
-                    space = {
-                      space = "file_picker";
-                      w = ":w";
-                      q = ":q";
+                    cursor-shape = {
+                      insert = "bar";
+                      normal = "block";
+                      select = "underline";
                     };
-                  };
-
-                  backspace = {
-                    b = {
-                      r = ":run-shell-command zellij run -fc -- cargo build";
-                      n = ":run-shell-command zellij run -f -- nix build";
+                    file-picker = {
+                      hidden = false;
+                      git-ignore = true;
                     };
-
-                    d = {
-                      d = ":run-shell-command zellij run -fc -- watch --color -n 0.2 lsd /dev/ttyACM* -h --color always";
-                      b = ":run-shell-command zellij run -fc -- btop";
+                    soft-wrap = {
+                      enable = true;
                     };
-
-                    r = {
-                      n = ":run-shell-command zellij run -f -- nix run";
-                      r = ":run-shell-command zellij run -fc -- cargo run";
+                    statusline = {
+                      left = [
+                        "mode"
+                        "file-name"
+                        "spinner"
+                      ];
+                      center = [ "position-percentage" ];
+                      right = [
+                        "version-control"
+                        "diagnostics"
+                        "selections"
+                        "position"
+                        "file-encoding"
+                        "file-line-ending"
+                        "file-type"
+                      ];
+                      separator = "│";
                     };
-
-                    t = {
-                      n = ":run-shell-command zellij run -f -- nix test";
-                      r = ":run-shell-command zellij run -fc -- cargo test";
+                    lsp = {
+                      enable = true;
+                      display-messages = true;
+                      auto-signature-help = true;
+                      # display-inlay-hints = true;
+                      display-signature-help-docs = true;
+                      snippets = true;
+                      goto-reference-include-declaration = true;
                     };
-
-                    g = ":run-shell-command zellij run -fc -- lazygit";
-                    f = ":run-shell-command zellij run -fc -- broot";
-                  };
-                };
-              };
-              languages = {
-
-                language-server =
-                  with pkgs;
-                  with pkgs.nodePackages_latest;
-                  {
-                    typescript-language-server = {
-                      command = "${typescript-language-server}/bin/typescript-language-server";
-                      args = [ "--stdio" ];
-                    };
-                    svelteserver.command = "${svelte-language-server}/bin/svelteserver";
-                    tailwindcss-ls.command = "${tailwindcss-language-server}/bin/tailwindcss-language-server";
-                    # nixd = {
-                    #   command = "${nixd}/bin/nixd";
-                    # };
-                    # eslint = {
-                    #   command = "${eslint}/bin/eslint";
-                    #   args = [ "--stdin" ];
-                    # };
-                    copilot = {
-                      command = "github-copilot-cli";
-                      args = [ "--stdio" ];
-                    };
-                    nil.command = "${nil}/bin/nil";
-                    rust-analyzer.command = "${rust-analyzer-unwrapped}/bin/rust-analyzer";
-                    rust-analyzer.config = {
-                      "inlayHints.bindingModeHints.enable" = true;
-                      "inlayHints.closingBraceHints.minLines" = 10;
-                      "inlayHints.closureReturnTypeHints.enable" = "with_block";
-                      "inlayHints.discrimiinantHints.enable" = "skip_trivial";
-                      "inlayHints.typeHints.hideClosureInitialization" = false;
-                    };
-
-                    yaml-language-server = {
-                      command = "${yaml-language-server}/bin/yaml-language-server";
-                      args = [ "--stdio" ];
-                      config.yaml.schemas = {
-                        "https://json.schemastore.org/github-action.json" = [
-                          "action.yml"
-                          "action.yaml"
-                        ];
+                    whitespace = {
+                      render = "all";
+                      characters = {
+                        space = " ";
+                        nbsp = "⍽";
+                        tab = "→";
+                        # newline = "⏎";
+                        tabpad = " "; # "·"; # Tabs will look like "→···" (depending on tab width)
                       };
                     };
+                    indent-guides = {
+                      render = true;
+                      character = "│"; # "╎";
+                    };
                   };
+                  keys.normal = {
+                    esc = [
+                      "collapse_selection"
+                      "keep_primary_selection"
+                    ];
+                    J = [
+                      "delete_selection"
+                      "paste_after"
+                    ];
+                    K = [
+                      "delete_selection"
+                      "move_line_up"
+                      "paste_before"
+                    ];
+                    C-u = [
+                      "half_page_up"
+                      "align_view_center"
+                    ];
+                    C-d = [
+                      "half_page_down"
+                      "align_view_center"
+                    ];
 
-                #https://github.com/helix-editor/helix/blob/master/languages.toml
-                language = [
-                  # {
-                  #   name = "json5";
-                  #   scope = "*";
-                  #   # shebangs = ["json"];
-                  # }
-                  {
-                    name = "javascript";
-                    formatter = {
-                      command = "prettier";
-                      args = [
-                        "--parser"
-                        "typescript"
+                    "[" = "goto_previous_buffer";
+                    "]" = "goto_next_buffer";
+
+                    g = {
+                      x = ":buffer-close";
+                      j = "jump_backward";
+                      k = "jump_forward";
+                    };
+                    space = {
+                      l = ":toggle lsp.display-inlay-hints";
+                      n = ":toggle lsp.auto-signature_help";
+
+                      space = {
+                        space = "file_picker";
+                        w = ":w";
+                        q = ":q";
+                      };
+                    };
+
+                    backspace = {
+                      b = {
+                        r = ":run-shell-command zellij run -fc -- cargo build";
+                        n = ":run-shell-command zellij run -f -- nix build";
+                      };
+
+                      d = {
+                        d = ":run-shell-command zellij run -fc -- watch --color -n 0.2 lsd /dev/ttyACM* -h --color always";
+                        b = ":run-shell-command zellij run -fc -- btop";
+                      };
+
+                      r = {
+                        n = ":run-shell-command zellij run -f -- nix run";
+                        r = ":run-shell-command zellij run -fc -- cargo run";
+                      };
+
+                      t = {
+                        n = ":run-shell-command zellij run -f -- nix test";
+                        r = ":run-shell-command zellij run -fc -- cargo test";
+                      };
+
+                      g = ":run-shell-command zellij run -fc -- lazygit";
+                      f = ":run-shell-command zellij run -fc -- broot";
+                    };
+                  };
+                };
+                languages = {
+
+                  language-server =
+                    with pkgs;
+                    with pkgs.nodePackages_latest;
+                    {
+                      typescript-language-server = {
+                        command = "${typescript-language-server}/bin/typescript-language-server";
+                        args = [ "--stdio" ];
+                      };
+                      svelteserver.command = "${svelte-language-server}/bin/svelteserver";
+                      tailwindcss-ls.command = "${tailwindcss-language-server}/bin/tailwindcss-language-server";
+                      # nixd = {
+                      #   command = "${nixd}/bin/nixd";
+                      # };
+                      # eslint = {
+                      #   command = "${eslint}/bin/eslint";
+                      #   args = [ "--stdin" ];
+                      # };
+                      copilot = {
+                        command = "github-copilot-cli";
+                        args = [ "--stdio" ];
+                      };
+                      nil.command = "${nil}/bin/nil";
+                      rust-analyzer.command = "${rust-analyzer-unwrapped}/bin/rust-analyzer";
+                      rust-analyzer.config = {
+                        "inlayHints.bindingModeHints.enable" = true;
+                        "inlayHints.closingBraceHints.minLines" = 10;
+                        "inlayHints.closureReturnTypeHints.enable" = "with_block";
+                        "inlayHints.discrimiinantHints.enable" = "skip_trivial";
+                        "inlayHints.typeHints.hideClosureInitialization" = false;
+                      };
+
+                      yaml-language-server = {
+                        command = "${yaml-language-server}/bin/yaml-language-server";
+                        args = [ "--stdio" ];
+                        config.yaml.schemas = {
+                          "https://json.schemastore.org/github-action.json" = [
+                            "action.yml"
+                            "action.yaml"
+                          ];
+                        };
+                      };
+                    };
+
+                  #https://github.com/helix-editor/helix/blob/master/languages.toml
+                  language = [
+                    # {
+                    #   name = "json5";
+                    #   scope = "*";
+                    #   # shebangs = ["json"];
+                    # }
+                    {
+                      name = "javascript";
+                      formatter = {
+                        command = "prettier";
+                        args = [
+                          "--parser"
+                          "typescript"
+                        ];
+                      };
+                      language-servers = [
+                        "typescript-language-server"
+                        "eslint"
                       ];
-                    };
-                    language-servers = [
-                      "typescript-language-server"
-                      "eslint"
-                    ];
-                    auto-format = true;
-                  }
-                  {
-                    name = "typescript";
-                    formatter = {
-                      command = "prettier";
-                      args = [
-                        "--parser"
-                        "typescript"
+                      auto-format = true;
+                    }
+                    {
+                      name = "typescript";
+                      formatter = {
+                        command = "prettier";
+                        args = [
+                          "--parser"
+                          "typescript"
+                        ];
+                      };
+                      language-servers = [
+                        "typescript-language-server"
+                        "eslint"
                       ];
-                    };
-                    language-servers = [
-                      "typescript-language-server"
-                      "eslint"
-                    ];
-                    auto-format = true;
-                  }
-                  {
-                    name = "svelte";
-                    formatter = {
-                      command = "prettier";
-                      args = [
-                        "--plugin"
-                        "prettier-plugin-svelte"
+                      auto-format = true;
+                    }
+                    {
+                      name = "svelte";
+                      formatter = {
+                        command = "prettier";
+                        args = [
+                          "--plugin"
+                          "prettier-plugin-svelte"
+                        ];
+                      };
+                      language-servers = [
+                        "tailwindcss-ls"
+                        "svelteserver"
+                        "eslint"
                       ];
-                    };
-                    language-servers = [
-                      "tailwindcss-ls"
-                      "svelteserver"
-                      "eslint"
-                    ];
-                    auto-format = true;
-                  }
-                  {
-                    name = "nix";
-                    auto-format = true;
-                    formatter = {
-                      command = "nixfmt"; # "nixpkgs-fmt";
-                    };
-                    language-servers = [
-                      "nixd"
-                      "nil"
-                      "copilot"
-                    ];
-                  }
-                  {
-                    name = "nim";
-                    auto-format = true;
-                    formatter = {
-                      command = "nimpretty";
-                    };
-                    # language-servers = [ "nimlsp" "nimlangserver" ];
-                  }
-                  {
-                    name = "python";
-                    language-servers = [
-                      "pylsp"
-                      "pyright"
-                    ];
-                    formatter = {
-                      command = "black";
-                      args = [
-                        "--quiet"
-                        "-"
+                      auto-format = true;
+                    }
+                    {
+                      name = "nix";
+                      auto-format = true;
+                      formatter = {
+                        command = "nixfmt"; # "nixpkgs-fmt";
+                      };
+                      language-servers = [
+                        "nixd"
+                        "nil"
+                        "copilot"
                       ];
-                    };
-                    auto-format = true;
-                  }
-                  {
-                    name = "rust";
-                    auto-format = true;
-                    language-servers = [
-                      "rust-analyzer"
-                      "copilot"
-                    ];
-                  }
-                  {
-                    name = "markdown";
-                    auto-format = true;
-                    formatter = {
-                      command = "dprint";
-                      args = [
-                        "fmt"
-                        "--stdin"
-                        "md"
+                    }
+                    {
+                      name = "nim";
+                      auto-format = true;
+                      formatter = {
+                        command = "nimpretty";
+                      };
+                      # language-servers = [ "nimlsp" "nimlangserver" ];
+                    }
+                    {
+                      name = "python";
+                      language-servers = [
+                        "pylsp"
+                        "pyright"
                       ];
-                    };
-                    language-servers = [
-                      "marksman"
-                    ];
-                  }
-                  {
-                    name = "yaml";
-                    scope = "source.yaml";
-                    file-types = [
-                      "yml"
-                      "yaml"
-                    ];
-                    auto-format = true;
-                    language-servers = [ "yaml-language-server" ];
-                  }
-                ];
+                      formatter = {
+                        command = "black";
+                        args = [
+                          "--quiet"
+                          "-"
+                        ];
+                      };
+                      auto-format = true;
+                    }
+                    {
+                      name = "rust";
+                      auto-format = true;
+                      language-servers = [
+                        "rust-analyzer"
+                        "copilot"
+                      ];
+                    }
+                    {
+                      name = "markdown";
+                      auto-format = true;
+                      formatter = {
+                        command = "dprint";
+                        args = [
+                          "fmt"
+                          "--stdin"
+                          "md"
+                        ];
+                      };
+                      language-servers = [
+                        "marksman"
+                      ];
+                    }
+                    {
+                      name = "yaml";
+                      scope = "source.yaml";
+                      file-types = [
+                        "yml"
+                        "yaml"
+                      ];
+                      auto-format = true;
+                      language-servers = [ "yaml-language-server" ];
+                    }
+                  ];
+                };
               };
-            };
-          }
-      )
-      config.my.users;
-  };
+            }
+        )
+        config.my.users;
+    }
+  ];
 }

--- a/my/users/environment/mynixos.nix
+++ b/my/users/environment/mynixos.nix
@@ -1,0 +1,52 @@
+# mynixos Opinionated Defaults: User Environment
+#
+# This file defines which environment applications are set when graphical.enable = true
+# Users can override by setting environment.BROWSER = pkgs.firefox; etc.
+
+{ lib, pkgs, ... }:
+
+{
+  options.my.users = lib.mkOption {
+    type = lib.types.attrsOf (lib.types.submodule ({ config, ... }: {
+      config = lib.mkIf (config.graphical.enable or false) {
+        environment = {
+          BROWSER = lib.mkDefault {
+            enable = true;
+            package = pkgs.brave;
+            settings = { };
+          };
+          TERMINAL = lib.mkDefault {
+            enable = true;
+            package = pkgs.wezterm;
+            settings = { };
+          };
+          EDITOR = lib.mkDefault {
+            enable = true;
+            package = pkgs.helix;
+            settings = { };
+          };
+          SHELL = lib.mkDefault {
+            enable = true;
+            package = pkgs.bashInteractive;
+            settings = { };
+          };
+          FILE_MANAGER = lib.mkDefault {
+            enable = true;
+            package = pkgs.yazi;
+            settings = { };
+          };
+          launcher = lib.mkDefault {
+            enable = true;
+            package = pkgs.walker;
+            settings = { };
+          };
+          multiplexer = lib.mkDefault {
+            enable = true;
+            package = pkgs.zellij;
+            settings = { };
+          };
+        };
+      };
+    }));
+  };
+}

--- a/my/users/users/environment-options.nix
+++ b/my/users/users/environment-options.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs, config, ... }:
+{ lib, ... }:
 
 let
   # App submodule: supports { package, settings } OR bare package via coercion
@@ -31,10 +31,6 @@ let
     lib.types.package
     (pkg: { package = pkg; })
     appSubmodule;
-
-  # Check if graphical is enabled for this user
-  # NOTE: config here is the USER submodule config (my.users.<name>)
-  isGraphical = config.graphical.enable or false;
 in
 {
   options.environment = lib.mkOption {
@@ -44,80 +40,44 @@ in
       options = {
         BROWSER = lib.mkOption {
           type = lib.types.nullOr coercedAppType;
-          # Set opinionated default only when graphical.enable = true
-          default =
-            if isGraphical then {
-              enable = true;
-              package = pkgs.brave;
-              settings = { };
-            } else null;
+          default = null;
           description = "Web browser (sets BROWSER environment variable). Opinionated default: brave when graphical.enable = true";
         };
 
         TERMINAL = lib.mkOption {
           type = lib.types.nullOr coercedAppType;
-          default =
-            if isGraphical then {
-              enable = true;
-              package = pkgs.wezterm;
-              settings = { };
-            } else null;
+          default = null;
           description = "Terminal emulator (sets TERMINAL environment variable). Opinionated default: wezterm when graphical.enable = true";
         };
 
         EDITOR = lib.mkOption {
           type = lib.types.nullOr coercedAppType;
-          default =
-            if isGraphical then {
-              enable = true;
-              package = pkgs.helix;
-              settings = { };
-            } else null;
+          default = null;
           description = "Text editor (sets EDITOR and VISUAL environment variables). Opinionated default: helix when graphical.enable = true";
         };
 
         SHELL = lib.mkOption {
           type = lib.types.nullOr coercedAppType;
-          default =
-            if isGraphical then {
-              enable = true;
-              package = pkgs.bashInteractive;
-              settings = { };
-            } else null;
+          default = null;
           description = "Shell (sets SHELL environment variable). Opinionated default: bash when graphical.enable = true";
         };
 
         FILE_MANAGER = lib.mkOption {
           type = lib.types.nullOr coercedAppType;
-          default =
-            if isGraphical then {
-              enable = true;
-              package = pkgs.yazi;
-              settings = { };
-            } else null;
+          default = null;
           description = "File manager (sets FILE_MANAGER environment variable). Opinionated default: yazi when graphical.enable = true";
         };
 
         # Non-standard env vars (lowercase for clarity that they're not standard)
         launcher = lib.mkOption {
           type = lib.types.nullOr coercedAppType;
-          default =
-            if isGraphical then {
-              enable = true;
-              package = pkgs.walker;
-              settings = { };
-            } else null;
+          default = null;
           description = "Application launcher (no standard environment variable). Opinionated default: walker when graphical.enable = true";
         };
 
         multiplexer = lib.mkOption {
           type = lib.types.nullOr coercedAppType;
-          default =
-            if isGraphical then {
-              enable = true;
-              package = pkgs.zellij;
-              settings = { };
-            } else null;
+          default = null;
           description = "Terminal multiplexer (no standard environment variable). Opinionated default: zellij when graphical.enable = true";
         };
       };

--- a/my/users/users/options.nix
+++ b/my/users/users/options.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs, ... }:
+{ lib, ... }:
 
 {
   users = lib.mkOption {
@@ -20,9 +20,6 @@
             ../themes/options.nix
             ./apps-options.nix
           ];
-
-          # Pass pkgs to submodule so environment.nix can use it in defaults
-          _module.args.pkgs = lib.mkForce pkgs;
         }
       )
     );

--- a/tests/integration-smoke.nix
+++ b/tests/integration-smoke.nix
@@ -213,4 +213,70 @@ in
       # Hyprland should be enabled at system level
       && config.programs.hyprland.enable;
   };
+
+  # Test 5: Unfree packages are properly allowlisted
+  # Verify that enabling apps with unfree licenses correctly populates
+  # my.system.allowedUnfreePackages so nixpkgs.config.allowUnfreePredicate works
+  smoke-unfree-allowlist = mkSmokeTest {
+    name = "test-unfree-allowlist";
+    myConfig = {
+      system.enable = true;
+      system.hostname = "test-unfree-allowlist";
+      users.testuser = {
+        fullName = "Test User";
+        description = "Test User";
+        email = "test@example.com";
+        graphical.enable = true;
+        dev.enable = true;
+        ai.enable = true;
+        terminal.enable = true;
+        # Explicitly enable unfree apps not in opinionated defaults
+        apps = {
+          dev.tools.vscode.enable = true;
+          security.passwords.onePassword.enable = true;
+          communication.messaging.slack.enable = true;
+        };
+      };
+    };
+    assertions = config:
+      let
+        allowed = config.my.system.allowedUnfreePackages;
+      in
+      # claude-code (unfree) - enabled by ai opinionated defaults
+      builtins.elem "claude-code" allowed
+      # github-copilot-cli (unfree) - enabled by helix (graphical default editor)
+      && builtins.elem "github-copilot-cli" allowed
+      # vscode (unfree) - explicitly enabled
+      && builtins.elem "vscode" allowed
+      # 1password (unfree) - explicitly enabled
+      && builtins.elem "1password" allowed
+      # slack (unfree) - explicitly enabled
+      && builtins.elem "slack" allowed;
+  };
+
+  # Test 6: Motherboard hostPlatform + graphical user (regression: pkgs recursion)
+  # Hardware modules that set nixpkgs.hostPlatform must not cause infinite recursion
+  # when user environment options resolve pkgs-based defaults.
+  smoke-motherboard-env = mkSmokeTest {
+    name = "test-motherboard-env";
+    myConfig = {
+      system.enable = true;
+      system.hostname = "test-motherboard-env";
+      hardware.motherboards.gigabyte.x870e-aorus-elite-wifi7.enable = true;
+      users.testuser = {
+        fullName = "Test User";
+        description = "Test User";
+        email = "test@example.com";
+        graphical.enable = true;
+        terminal.enable = true;
+      };
+    };
+    assertions = config:
+      # Environment defaults should be populated for graphical user
+      config.my.users.testuser.environment.BROWSER != null
+      && config.my.users.testuser.environment.TERMINAL != null
+      && config.my.users.testuser.environment.EDITOR != null
+      # System graphical should be auto-derived
+      && config.my.graphical.enable;
+  };
 }


### PR DESCRIPTION
## Summary

- Decouple `pkgs` from option-definition modules to break the cycle: `pkgs` → `config.nixpkgs` → module evaluation → `pkgs` (infinite recursion when hardware modules set `nixpkgs.hostPlatform`)
- Move environment defaults to `mynixos.nix` opinionated defaults pattern (matching existing `graphical`, `dev`, `ai`, `terminal` patterns)
- Add per-package unfree allowlist entries in the modules that use them: `claude-code`, `github-copilot-cli` (helix), `slack`, and NVIDIA/CUDA packages
- Use `mkDefault` for `my.ai.enable` auto-derivation to avoid conflicts with explicit user config
- Add `smoke-unfree-allowlist` regression test verifying all unfree apps populate `allowedUnfreePackages`

## Test plan

- [x] `nix flake check` passes on mynixos (all smoke tests, type validation, formatting, linting)
- [x] `nix flake check` passes on `/etc/nixos` (yoga + skyspy-dev + installer-iso)
- [x] New `smoke-unfree-allowlist` test verifies claude-code, github-copilot-cli, vscode, 1password, slack are in allowlist
- [x] Existing `smoke-motherboard-env` test verifies no recursion with `nixpkgs.hostPlatform`

Closes #75