### PR TITLE
fix(apps): mkApp must source pkgs from config — hotfix for broken real builds (#119 regression)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -489,11 +489,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781203987,
-        "narHash": "sha256-JPzEbnQtZfIEC5gsET08Ie/6GYbqHkuyBDmKhuwB1EI=",
+        "lastModified": 1781259653,
+        "narHash": "sha256-a1jSppP24tEUSxmVrX1Xi6spCOX3DPdqkF2pGf9MoAQ=",
         "owner": "i-am-logger",
         "repo": "home-manager",
-        "rev": "58550a28b24a5734e9fc955123bee33623feeb9f",
+        "rev": "e8215caddebd792188b9c5045abb92d5802e1d6e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -487,6 +487,11 @@
           edgeCaseTests = import ./tests/persistence-and-edge-cases.nix {
             inherit self inputs system;
           };
+          # Regression: evaluate a system the mkSystem way (pkgs NOT in
+          # specialArgs) so mkApp's pkgs sourcing is actually exercised.
+          realPkgsTest = import ./tests/real-system-pkgs.nix {
+            inherit lib nixpkgs system self inputs;
+          };
         in
         {
           formatting = treefmtEval.${system}.config.build.check self;
@@ -506,6 +511,7 @@
         // lib.mapAttrs' (name: value: lib.nameValuePair name value) typeValidationTests
         // smokeTests
         // edgeCaseTests
+        // realPkgsTest
       );
 
       # Heavy booting VM tests, kept OUT of `checks` so `nix flake check` stays

--- a/lib/mk-app.nix
+++ b/lib/mk-app.nix
@@ -33,6 +33,14 @@
 
       activeUsers = import ./active-users.nix lib;
 
+      # `pkgs` is a _module.args entry: the module system only injects it into
+      # modules that NAME it. The app modules are bare `args:` lambdas (naming
+      # pkgs would make deadnix flag it as unused), so they do NOT receive pkgs —
+      # `mkSystem` does not pass it via specialArgs either. Source it from config
+      # (where the nixpkgs module stores it) so `home` always gets it. In the test
+      # harness pkgs IS a specialArg, so it stays in moduleArgs and short-circuits.
+      pkgs = moduleArgs.pkgs or config._module.args.pkgs;
+
       pathList = splitString "." spec.path;
       getCfg = userCfg:
         attrByPath pathList
@@ -45,7 +53,7 @@
       perUser = mapAttrs
         (name: userCfg:
           let cfg = getCfg userCfg;
-          in mkIf cfg.enable (home (moduleArgs // { inherit cfg userCfg name; })))
+          in mkIf cfg.enable (home (moduleArgs // { inherit cfg userCfg name pkgs; })))
         (activeUsers config.my.users);
 
       anyEnabled = any

--- a/tests/real-system-pkgs.nix
+++ b/tests/real-system-pkgs.nix
@@ -17,10 +17,11 @@ let
   hostPkgs = nixpkgs.legacyPackages.${system};
 
   eval = lib.nixosSystem {
-    # Mirror lib/mkSystem.nix specialArgs — note the ABSENCE of `pkgs`.
+    # Match lib/mkSystem.nix specialArgs EXACTLY — note the absence of `pkgs`
+    # (mkSystem does not pass it; that is precisely what this test exercises).
+    # sops-nix is imported as a module below, not a specialArg (as in mkSystem).
     specialArgs = {
-      inherit inputs self system;
-      secrets = null;
+      inherit inputs;
       inherit (inputs)
         disko
         impermanence
@@ -28,8 +29,9 @@ let
         vogix
         hypr-vogix
         lanzaboote
-        sops-nix
+        self
         ;
+      secrets = inputs.secrets or null;
     };
     modules = [
       self.nixosModules.default

--- a/tests/real-system-pkgs.nix
+++ b/tests/real-system-pkgs.nix
@@ -1,0 +1,72 @@
+# Regression test for the mkApp pkgs-provisioning bug.
+#
+# The migrated app modules are bare `args:` lambdas, so the module system only
+# gives them `pkgs` if something NAMES it. `mkSystem` (the real builder) does NOT
+# pass `pkgs` via specialArgs — pkgs comes from the nixpkgs module via config.
+# An earlier version of mkApp forwarded its own (pkgs-less) module args straight
+# to each app's `home`, so any app whose home used `pkgs` failed the real build
+# with "function 'home' called without required argument 'pkgs'".
+#
+# Crucially, the other test harnesses (tests/lib.nix and the VM test) pass `pkgs`
+# via specialArgs, which MASKED the bug. This test deliberately evaluates a system
+# the mkSystem way — pkgs NOT in specialArgs — and forces an app whose home uses
+# pkgs (jq: `home = { pkgs, ... }: { home.packages = [ pkgs.jq ]; }`).
+{ lib, nixpkgs, system, self, inputs }:
+
+let
+  hostPkgs = nixpkgs.legacyPackages.${system};
+
+  eval = lib.nixosSystem {
+    # Mirror lib/mkSystem.nix specialArgs — note the ABSENCE of `pkgs`.
+    specialArgs = {
+      inherit inputs self system;
+      secrets = null;
+      inherit (inputs)
+        disko
+        impermanence
+        stylix
+        vogix
+        hypr-vogix
+        lanzaboote
+        sops-nix
+        ;
+    };
+    modules = [
+      self.nixosModules.default
+      inputs.home-manager.nixosModules.home-manager
+      inputs.sops-nix.nixosModules.sops
+      {
+        boot.loader.grub.devices = [ "nodev" ];
+        fileSystems."/" = {
+          device = "tmpfs";
+          fsType = "tmpfs";
+        };
+        system.stateVersion = "24.11";
+        nixpkgs.hostPlatform = system;
+        networking.hostName = "pkgs-regression";
+
+        my.users.alice = {
+          fullName = "Alice";
+          # jq is a light, free app whose mkApp `home` uses `pkgs`.
+          apps.dev.tools.jq.enable = true;
+        };
+        home-manager = {
+          useUserPackages = true;
+          backupFileExtension = "backup";
+          sharedModules = [{ home.stateVersion = "24.11"; }];
+          users.alice = { };
+        };
+      }
+    ];
+  };
+
+  # Forcing alice's home.packages forces the jq app module's `home`, which
+  # references `pkgs`. With the bug, this throws at eval.
+  forced = builtins.length eval.config.home-manager.users.alice.home.packages;
+in
+{
+  real-system-pkgs = hostPkgs.runCommand "real-system-pkgs" { } ''
+    echo "alice home.packages evaluated (count: ${toString forced}) without a pkgs specialArg"
+    touch $out
+  '';
+}


### PR DESCRIPTION
## Hotfix: `mkApp` broke real system builds (regression from #119)

**master currently fails to build.** The app-module refactor in #119 collapsed 39 modules into bare `args:` lambdas calling `mkApp`. But `pkgs` is a `_module.args` entry the module system only injects into modules that *name* it — a bare `args:` lambda never receives it, and `mkSystem` does **not** pass `pkgs` via `specialArgs`. So `mkApp` forwarded a `pkgs`-less arg set to each app's `home`, and the first app whose home uses `pkgs` aborts the real build:

```
error: function 'home' called without required argument 'pkgs'
  …/my/users/apps/visualizers/bespec/default.nix:5: home = { pkgs, userCfg, ... }:
```

This reproduces with `rebuild-system` / `nix build .#nixosConfigurations.<host>.config.system.build.toplevel`.

**Why CI was green anyway:** both `tests/lib.nix` and the VM test pass `pkgs` via `specialArgs` (always provided), which masked the bug — every check passed while the real builder failed.

### Fix

`mkApp` now sources `pkgs` from `config` (where the nixpkgs module stores it) instead of relying on the app module naming it:

```nix
pkgs = moduleArgs.pkgs or config._module.args.pkgs;
```

### Regression test

`tests/real-system-pkgs.nix` evaluates a system the `mkSystem` way — `pkgs` **not** in `specialArgs` — and forces an app whose `home` uses `pkgs` (jq). Verified to **pass with the fix and fail without it** (the exact `home called without required argument 'pkgs'` error), so this class can't hide again.

### Also bundled

`chore(flake): bump home-manager` — picks up PR #7917 webapps changes (non-nullable `startupWmClass` defaulting to `webapp-<name>`, and an optional per-app `browser` override). mynixos's consumer sets both explicitly, so it's behavior-preserving.

### Verification

- `nix eval .#nixosConfigurations.yoga.config.system.build.toplevel.drvPath` → ✅ (was the crash site)
- `nixos-rebuild build` (full closure) → ✅
- `nix flake check` (incl. new regression test) → ✅ green
