### PR TITLE
feat(security): add my.security.tpm to suppress unused NvPCR measured-boot setup

### DIFF
--- a/my/security/default.nix
+++ b/my/security/default.nix
@@ -51,9 +51,11 @@ in
 
       # Remove ONLY the NvPCR anchor credentials (never pcrlock or other creds),
       # at boot. The stub still packs whatever is present this boot, so the line
-      # clears from the next boot onward (once the ESP dir is empty).
+      # clears from the next boot onward (once the ESP dir is empty). Path follows
+      # the configured ESP mountpoint (efiSysMountPoint, mkDefault "/boot") so it
+      # still tracks the real credentials dir on hosts that relocate the ESP.
       systemd.tmpfiles.rules = [
-        "r! /boot/loader/credentials/nvpcr-anchor.*.cred"
+        "r! ${config.boot.loader.efi.efiSysMountPoint}/loader/credentials/nvpcr-anchor.*.cred"
       ];
     })
 

--- a/my/security/default.nix
+++ b/my/security/default.nix
@@ -36,6 +36,27 @@ in
       };
     })
 
+    # TPM2 measured boot: when the TPM isn't used (tpm.enable = false, the
+    # default), disable systemd's NvPCR/SRK setup so it stops writing a new
+    # nvpcr-anchor credential to the ESP every generation, and remove the stale
+    # ones. Otherwise they accumulate (one per generation) and PID1's
+    # import-creds logs them as "untrusted credentials" on every boot — they are
+    # measured into PCR 12 but never required, so it's pure noise without FDE.
+    # Flip tpm.enable = true when adopting TPM-sealed disk unlock (it needs the SRK).
+    (mkIf (cfg.enable && !cfg.tpm.enable) {
+      systemd.services = {
+        systemd-tpm2-setup.enable = false;
+        systemd-tpm2-setup-early.enable = false;
+      };
+
+      # Remove ONLY the NvPCR anchor credentials (never pcrlock or other creds),
+      # at boot. The stub still packs whatever is present this boot, so the line
+      # clears from the next boot onward (once the ESP dir is empty).
+      systemd.tmpfiles.rules = [
+        "r! /boot/loader/credentials/nvpcr-anchor.*.cred"
+      ];
+    })
+
     # YubiKey configuration (enabled when security stack is enabled and any user has yubikey)
     (mkIf (cfg.enable && (cfg.yubikey.enable || hasYubikey)) {
       services = {

--- a/my/security/options.nix
+++ b/my/security/options.nix
@@ -12,6 +12,15 @@
           enable = lib.mkEnableOption "secure boot with lanzaboote";
         };
 
+        # TPM2 measured-boot setup (systemd-tpm2-setup: the SRK + systemd 259's
+        # NvPCR anchors). OFF by default: when the TPM isn't used (no TPM-backed
+        # FDE), the setup is disabled and the per-generation NvPCR anchor creds it
+        # writes to the ESP — which PID1 reports as "untrusted credentials" every
+        # boot — are cleaned up. Turn ON when adopting TPM-sealed disk unlock.
+        tpm = {
+          enable = lib.mkEnableOption "TPM2 measured-boot setup (SRK + NvPCR anchors)";
+        };
+
         yubikey = {
           enable = lib.mkEnableOption "yubikey support";
         };


### PR DESCRIPTION
## What

Adds a `my.security.tpm` sub-domain (off by default, beside `secureBoot`) to the security stack.

systemd 259's `systemd-tpm2-setup` writes a per-generation `nvpcr-anchor.*.cred` to the ESP for its NvPCR measured-boot anchors. Without TPM-backed FDE these accumulate (one per generation) and PID1's credential import logs them as "N untrusted credentials" on every boot — they're measured into PCR 12 but never required, so it's pure noise on a box that seals nothing to the TPM.

When the TPM isn't used (`tpm.enable = false`, the default for this fleet — lanzaboote secure boot, no LUKS):
- disable `systemd-tpm2-setup` and `systemd-tpm2-setup-early`
- sweep the stale anchor creds from the ESP via a tmpfiles `r!` rule, with the glob pinned to `nvpcr-anchor.*.cred` so it never touches pcrlock or other credentials

Flip `tpm.enable = true` when adopting TPM-sealed disk unlock (it needs the SRK).

## Files
- `my/security/options.nix` — new `tpm.enable` option under the security domain
- `my/security/default.nix` — the disable + cleanup behaviour, gated on `cfg.enable && !cfg.tpm.enable`

## Notes
Off by default and scoped to the no-TPM case, so it's a no-op for any host that later sets `tpm.enable = true`. yoga already consumes it (`security.tpm.enable = false`).
