### PR TITLE
fix(hardware/k2-he): correct the OpenRGB registration note

### DIFF
--- a/my/hardware/peripherals/keychron/k2-he/default.nix
+++ b/my/hardware/peripherals/keychron/k2-he/default.nix
@@ -37,7 +37,7 @@ in
     # firmware: its OpenRGB command handler was never compiled in (a QMK
     # build-wiring bug), so the keyboard never answered the protocol and
     # OpenRGB kept re-probing/resetting the device. Fixed 2026-06-14 in
-    # qmk PR Keychron/qmk_firmware#476; OpenRGB has since enumerated and
+    # QMK PR Keychron/qmk_firmware#476; OpenRGB has since enumerated and
     # managed the keyboard with no hub cycling. Revert to disabled if it recurs.
     # my.theming.openrgb.qmkDevices = mkIf cfg.enable [{ name = "Keychron K2 HE"; vid = "0x3434"; pid = "0x0E20"; }];
   };

--- a/my/hardware/peripherals/keychron/k2-he/default.nix
+++ b/my/hardware/peripherals/keychron/k2-he/default.nix
@@ -24,15 +24,21 @@ in
     # Only when device is enabled
     services.udev.packages = mkIf (cfg.enable && cfg.udev) [ udevRules ];
 
-    # NOTE: The K2 HE is intentionally *not* registered as a QMK OpenRGB device.
-    # Empirical evidence on yoga (2026-04-14): when OpenRGB runs with the K2 HE
-    # as a managed QMK device, the keyboard's internal Genesys Logic USB hub
-    # enters spontaneous disconnect/reconnect cycles (~4-10 min intervals),
-    # taking the keyboard, the downstream Logitech receiver, and the YubiKey
-    # offline together each time. Stopping the openrgb.service stops the
-    # cycles entirely. Leaving the entry commented out until upstream OpenRGB
-    # fixes its K2 HE driver or we move RGB control to a dedicated hidraw
-    # path that doesn't bind the hub endpoint.
+    # The K2 HE IS registered as a QMK OpenRGB device -- via the vogix path:
+    # my.theming.vogix sets vogix.hardware.keychron-k2-he.enable, whose module
+    # adds it to vogix.openrgb.qmkDevices and writes it into /var/lib/OpenRGB.
+    # The my.theming.openrgb line below is the legacy native path, kept
+    # commented so the same device isn't registered twice.
+    #
+    # History: a 2026-04-14 note here disabled registration because OpenRGB
+    # managing the K2 HE made the keyboard's Genesys Logic USB hub cycle
+    # (disconnect/reconnect every ~4-10 min, dragging the Logitech receiver
+    # and YubiKey offline with it). Root cause was traced to the K2 HE
+    # firmware: its OpenRGB command handler was never compiled in (a QMK
+    # build-wiring bug), so the keyboard never answered the protocol and
+    # OpenRGB kept re-probing/resetting the device. Fixed 2026-06-14 in
+    # qmk PR Keychron/qmk_firmware#476; OpenRGB has since enumerated and
+    # managed the keyboard with no hub cycling. Revert to disabled if it recurs.
     # my.theming.openrgb.qmkDevices = mkIf cfg.enable [{ name = "Keychron K2 HE"; vid = "0x3434"; pid = "0x0E20"; }];
   };
 }


### PR DESCRIPTION
## What

Corrects a now-misleading note in the K2 HE hardware module. Comment-only change.

The note claimed the K2 HE was *intentionally not registered* as a QMK OpenRGB device because OpenRGB management cycled the keyboard's Genesys Logic USB hub (disconnect/reconnect every ~4-10 min, dragging the Logitech receiver and YubiKey offline with it; observed 2026-04-14).

That root cause was the **K2 HE firmware**: its OpenRGB command handler was never compiled into the firmware (a build-wiring bug), so the keyboard never answered the protocol and OpenRGB kept re-probing/resetting the device. Fixed upstream in `Keychron/qmk_firmware#476` — OpenRGB now enumerates and manages the keyboard cleanly with no hub cycling.

The K2 HE **is** registered via the vogix path (`my.theming.vogix` → `vogix.hardware.keychron-k2-he`); the `my.theming.openrgb` line here stays commented to avoid double-registering the same device. The old note would have misled us into disabling a working setup.
