### PR TITLE
fix(deps): vogix 0.8.0 + nixpkgs deprecation fixes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -159,11 +159,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781195293,
-        "narHash": "sha256-C9OFghpvf3RzK2rGsZjjNNrTrHgFOecEkpDhFnU4QGs=",
+        "lastModified": 1781627264,
+        "narHash": "sha256-TPj5d5MUyvuQZjsfDAAoYJ0SB+tNNNBrdCpD8XL0WeU=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "5f5109c83854577191634f7b86fc6e0c8fd44964",
+        "rev": "0fe5629a2955141c336b95e384e2c793c01214fb",
         "type": "github"
       },
       "original": {
@@ -931,11 +931,11 @@
         "vogix16-themes": "vogix16-themes"
       },
       "locked": {
-        "lastModified": 1781644630,
-        "narHash": "sha256-4iJAO+15V7ix5D7tmOcVos022xLxLx0I2QCQwOpODlQ=",
+        "lastModified": 1781721001,
+        "narHash": "sha256-ElDHGis+5nYaZwtz5le+LFazOEtXGkSUnnLEVeh4B2Q=",
         "owner": "i-am-logger",
         "repo": "vogix",
-        "rev": "27981db94afe918bba3845bd94e5f22ed6705513",
+        "rev": "5f04ff6d6dbc6e46567fd94fddbb45f18b496393",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -72,24 +72,30 @@
       "inputs": {
         "devenv": [
           "vogix",
-          "crate2nix"
+          "devenv"
         ],
         "flake-compat": [
           "vogix",
-          "crate2nix"
+          "devenv",
+          "flake-compat"
         ],
-        "git-hooks": "git-hooks_2",
+        "git-hooks": [
+          "vogix",
+          "devenv",
+          "git-hooks"
+        ],
         "nixpkgs": [
           "vogix",
+          "devenv",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1767714506,
-        "narHash": "sha256-WaTs0t1CxhgxbIuvQ97OFhDTVUGd1HA+KzLZUZBhe0s=",
+        "lastModified": 1777487137,
+        "narHash": "sha256-TuvKVBX60mqyMT6OB5JqVEh1YIWtFMR/igLCaCdC9tw=",
         "owner": "cachix",
         "repo": "cachix",
-        "rev": "894c649f0daaa38bbcfb21de64be47dfa7cd0ec9",
+        "rev": "a66a440c321d35f7193472c317f42a55ccd1cb93",
         "type": "github"
       },
       "original": {
@@ -115,50 +121,29 @@
       }
     },
     "crate2nix": {
-      "inputs": {
-        "cachix": "cachix",
-        "devshell": "devshell",
-        "flake-compat": "flake-compat_2",
-        "flake-parts": "flake-parts_2",
-        "nix-test-runner": "nix-test-runner",
-        "nixpkgs": [
-          "vogix",
-          "nixpkgs"
-        ],
-        "pre-commit-hooks": "pre-commit-hooks"
-      },
+      "flake": false,
       "locked": {
-        "lastModified": 1773799810,
-        "narHash": "sha256-0VyaHRFWoAbkNFvG892c5nXKyLnOhyiY/LVzOWX9dcc=",
-        "owner": "i-am-logger",
+        "lastModified": 1772186516,
+        "narHash": "sha256-8s28pzmQ6TOIUzznwFibtW1CMieMUl1rYJIxoQYor58=",
+        "owner": "rossng",
         "repo": "crate2nix",
-        "rev": "49d369e525db13646a790b53f8ff870778499293",
+        "rev": "ba5dd398e31ee422fbe021767eb83b0650303a6e",
         "type": "github"
       },
       "original": {
-        "owner": "i-am-logger",
-        "ref": "fix/remove-crate2nix-stable-input",
+        "owner": "rossng",
         "repo": "crate2nix",
+        "rev": "ba5dd398e31ee422fbe021767eb83b0650303a6e",
         "type": "github"
       }
     },
     "devenv": {
       "inputs": {
-        "cachix": [
-          "vogix",
-          "crate2nix",
-          "cachix"
-        ],
-        "flake-compat": [
-          "vogix",
-          "crate2nix",
-          "flake-compat"
-        ],
-        "flake-parts": [
-          "vogix",
-          "crate2nix",
-          "flake-parts"
-        ],
+        "cachix": "cachix",
+        "crate2nix": "crate2nix",
+        "flake-compat": "flake-compat_3",
+        "flake-parts": "flake-parts_2",
+        "ghostty": "ghostty",
         "git-hooks": [
           "git-hooks"
         ],
@@ -167,41 +152,23 @@
         "nixpkgs": [
           "vogix",
           "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1768815419,
-        "narHash": "sha256-Kpol6rStnF9X2AJ35x8A7/dMF6eiJatktRMM9MOtchQ=",
-        "owner": "cachix",
-        "repo": "devenv",
-        "rev": "81552494542f06f8eda3da2b1f0b08f3ce79fa60",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "devenv",
-        "type": "github"
-      }
-    },
-    "devshell": {
-      "inputs": {
-        "nixpkgs": [
+        ],
+        "rust-overlay": [
           "vogix",
-          "crate2nix",
-          "nixpkgs"
+          "rust-overlay"
         ]
       },
       "locked": {
-        "lastModified": 1768818222,
-        "narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",
-        "owner": "numtide",
-        "repo": "devshell",
-        "rev": "255a2b1725a20d060f566e4755dbf571bbbb5f76",
+        "lastModified": 1781195293,
+        "narHash": "sha256-C9OFghpvf3RzK2rGsZjjNNrTrHgFOecEkpDhFnU4QGs=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "5f5109c83854577191634f7b86fc6e0c8fd44964",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "devshell",
+        "owner": "cachix",
+        "repo": "devenv",
         "type": "github"
       }
     },
@@ -258,17 +225,35 @@
       }
     },
     "flake-compat_2": {
+      "flake": false,
       "locked": {
-        "lastModified": 1733328505,
-        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
-        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
-        "revCount": 69,
-        "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.1.0/01948eb7-9cba-704f-bbf3-3fa956735b52/source.tar.gz"
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
       }
     },
     "flake-parts": {
@@ -296,36 +281,21 @@
       "inputs": {
         "nixpkgs-lib": [
           "vogix",
-          "crate2nix",
+          "devenv",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1768135262,
-        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-root": {
-      "locked": {
-        "lastModified": 1723604017,
-        "narHash": "sha256-rBtQ8gg+Dn4Sx/s+pvjdq3CB2wQNzx9XGFq/JVGCB6k=",
-        "owner": "srid",
-        "repo": "flake-root",
-        "rev": "b759a56851e10cb13f6b8e5698af7b59c44be26e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "repo": "flake-root",
         "type": "github"
       }
     },
@@ -345,6 +315,22 @@
         "type": "github"
       }
     },
+    "ghostty": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1779069789,
+        "narHash": "sha256-ojo+gso45/6CVSuqfSVnlWpQ4d0QeLgwok+v/g3yu0E=",
+        "owner": "ghostty-org",
+        "repo": "ghostty",
+        "rev": "4b7bf0b20e3baf9c1ba10c63f2ad1fd853faea8f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ghostty-org",
+        "repo": "ghostty",
+        "type": "github"
+      }
+    },
     "git-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
@@ -359,36 +345,6 @@
         "owner": "cachix",
         "repo": "git-hooks.nix",
         "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "git-hooks_2": {
-      "inputs": {
-        "flake-compat": [
-          "vogix",
-          "crate2nix",
-          "cachix",
-          "flake-compat"
-        ],
-        "gitignore": "gitignore_2",
-        "nixpkgs": [
-          "vogix",
-          "crate2nix",
-          "cachix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1765404074,
-        "narHash": "sha256-+ZDU2d+vzWkEJiqprvV5PR26DVFN2vgddwG5SnPZcUM=",
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "rev": "2d6f58930fbcd82f6f9fd59fb6d13e37684ca529",
         "type": "github"
       },
       "original": {
@@ -421,33 +377,8 @@
     "gitignore_2": {
       "inputs": {
         "nixpkgs": [
-          "vogix",
-          "crate2nix",
-          "cachix",
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "gitignore_3": {
-      "inputs": {
-        "nixpkgs": [
-          "vogix",
-          "crate2nix",
-          "pre-commit-hooks",
+          "lanzaboote",
+          "pre-commit",
           "nixpkgs"
         ]
       },
@@ -489,11 +420,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781259653,
-        "narHash": "sha256-a1jSppP24tEUSxmVrX1Xi6spCOX3DPdqkF2pGf9MoAQ=",
+        "lastModified": 1781297513,
+        "narHash": "sha256-yjMBNCcWi4zCUqUjrgp9VxIys+MAAfqH1wyENNn0h7w=",
         "owner": "i-am-logger",
         "repo": "home-manager",
-        "rev": "e8215caddebd792188b9c5045abb92d5802e1d6e",
+        "rev": "ee91e5e635834893c5dd5bab70d16487f895a164",
         "type": "github"
       },
       "original": {
@@ -572,11 +503,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1781181476,
-        "narHash": "sha256-4JLkQvN7/f77TyxXXtoEuUfovMqMLOgWpBaLMNX1dns=",
+        "lastModified": 1781649287,
+        "narHash": "sha256-ycG9a7svaV/zF9G03waY7BqUcNQn2HODMN/lXy3C7Zc=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "0403b4b7e8b2612657f0053a4c315e6c43eee9e6",
+        "rev": "001e560fffc8f0235e9db20ebeb4ccde0ade1caf",
         "type": "github"
       },
       "original": {
@@ -588,11 +519,11 @@
     "liquidctl-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1775539741,
-        "narHash": "sha256-tOKjBnrpMZSz4SEbnJhelfH+X9F3fSpZ62CiGDoSFZs=",
+        "lastModified": 1781124321,
+        "narHash": "sha256-zNo0HMsT7v1Rzx4iPOAs5yz12zKTRFAUqdXcAIFhRq8=",
         "owner": "i-am-logger",
         "repo": "liquidctl",
-        "rev": "708a375c7ef284a05577f956ec24673d03e2b409",
+        "rev": "d8f72b56c1ffefbc44c9140b3fb5df3c5eec4cf5",
         "type": "github"
       },
       "original": {
@@ -634,33 +565,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1768491252,
-        "narHash": "sha256-ZlIPlKCYXwQJsw9WYVeyCapF5Y8JZL2Hctf22+IbHqo=",
+        "lastModified": 1779748925,
+        "narHash": "sha256-meIhqGC04O5VXbKSFXSQoOKp+XCq5RMnwAk1Guo0VQo=",
         "owner": "cachix",
         "repo": "nix",
-        "rev": "9f0da1cd90b271569752a4c83f3ff700b8fcbe12",
+        "rev": "0bc443c8ff235c3547d09327b48aaa2ab98b15f2",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
-        "ref": "devenv-2.32",
+        "ref": "devenv-2.34",
         "repo": "nix",
-        "type": "github"
-      }
-    },
-    "nix-test-runner": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1588761593,
-        "narHash": "sha256-FKJykltAN/g3eIceJl4SfDnnyuH2jHImhMrXS2KvGIs=",
-        "owner": "stoeffel",
-        "repo": "nix-test-runner",
-        "rev": "c45d45b11ecef3eb9d834c3b6304c05c49b06ca2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "stoeffel",
-        "repo": "nix-test-runner",
         "type": "github"
       }
     },
@@ -671,7 +586,6 @@
           "devenv",
           "flake-parts"
         ],
-        "flake-root": "flake-root",
         "nixpkgs": [
           "vogix",
           "devenv",
@@ -680,11 +594,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1763964548,
-        "narHash": "sha256-JTRoaEWvPsVIMFJWeS4G2isPo15wqXY/otsiHPN0zww=",
+        "lastModified": 1778381404,
+        "narHash": "sha256-FqhdOTA8vyoIpkHhbs2cCT7h6EWM7nsLeOYJc1ifQLE=",
         "owner": "nix-community",
         "repo": "nixd",
-        "rev": "d4bf15e56540422e2acc7bc26b20b0a0934e3f5e",
+        "rev": "e3e45eb76663f522e196b7f0cf34cab201db7779",
         "type": "github"
       },
       "original": {
@@ -710,11 +624,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780749050,
-        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {
@@ -750,17 +664,8 @@
     },
     "pre-commit": {
       "inputs": {
-        "flake-compat": [
-          "vogix",
-          "crate2nix",
-          "flake-compat"
-        ],
-        "gitignore": [
-          "vogix",
-          "crate2nix",
-          "pre-commit-hooks",
-          "gitignore"
-        ],
+        "flake-compat": "flake-compat_2",
+        "gitignore": "gitignore_2",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -771,34 +676,6 @@
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
         "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "type": "github"
-      }
-    },
-    "pre-commit-hooks": {
-      "inputs": {
-        "flake-compat": [
-          "vogix",
-          "crate2nix",
-          "flake-compat"
-        ],
-        "gitignore": "gitignore_3",
-        "nixpkgs": [
-          "vogix",
-          "crate2nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1769069492,
-        "narHash": "sha256-Efs3VUPelRduf3PpfPP2ovEB4CXT7vHf8W+xc49RL/U=",
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "a1ef738813b15cf8ec759bdff5761b027e3e1d23",
         "type": "github"
       },
       "original": {
@@ -831,11 +708,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780802404,
-        "narHash": "sha256-bGtIUeLb0yChX4h6hB40OOCwcYhcpQZHXSDvZGdWgeM=",
+        "lastModified": 1781407245,
+        "narHash": "sha256-VzJq4MmD0uyNDAceudSe1hHqcQMe9Tau0U4S+5iRGh0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8e596a8430f2ce54d55c742198187d6945a5501e",
+        "rev": "d5f483210eb016d66102eef22baa128b3b3233fc",
         "type": "github"
       },
       "original": {
@@ -1022,11 +899,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734704479,
-        "narHash": "sha256-MMi74+WckoyEWBRcg/oaGRvXC9BVVxDZNRMpL+72wBI=",
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "65712f5af67234dad91a5a4baee986a8b62dbf8f",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
         "type": "github"
       },
       "original": {
@@ -1037,7 +914,6 @@
     },
     "vogix": {
       "inputs": {
-        "crate2nix": "crate2nix",
         "devenv": "devenv",
         "home-manager": [
           "home-manager"
@@ -1055,11 +931,11 @@
         "vogix16-themes": "vogix16-themes"
       },
       "locked": {
-        "lastModified": 1775551468,
-        "narHash": "sha256-WTq1Lw/9V419OwstLNzL5Mw1PEo7fqnxDOFvNLv4hUw=",
+        "lastModified": 1781644630,
+        "narHash": "sha256-4iJAO+15V7ix5D7tmOcVos022xLxLx0I2QCQwOpODlQ=",
         "owner": "i-am-logger",
         "repo": "vogix",
-        "rev": "64ffb3458bf8c20d3297fc07420744b700e42c48",
+        "rev": "27981db94afe918bba3845bd94e5f22ed6705513",
         "type": "github"
       },
       "original": {
@@ -1071,11 +947,11 @@
     "vogix16-themes": {
       "flake": false,
       "locked": {
-        "lastModified": 1775536832,
-        "narHash": "sha256-j4x1JuSnqfaEcu85bbaZoC6yriylSvsyFdq/OMqYbjo=",
+        "lastModified": 1781644806,
+        "narHash": "sha256-yRoklx45rknOyu3A9DhtqEex1ZL+pjg0ZbHytUb8k+4=",
         "owner": "i-am-logger",
         "repo": "vogix16-themes",
-        "rev": "a3a4671c5b7b9e877cdd5e384281651d9a17eb6e",
+        "rev": "ca0ad769211b2c5cac974b15fd52128c163f1b0a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -39,8 +39,9 @@
         nixpkgs.follows = "nixpkgs";
         home-manager.follows = "home-manager";
         tinted-schemes.url = "github:i-am-logger/tinted-schemes";
-        # Track vogix16-themes directly (vogix's own lock can lag its releases),
-        # so mynixos always builds against the latest theme set.
+        # Track vogix16-themes directly rather than through vogix's lock (which
+        # can lag its releases). Still pinned by flake.lock — a `nix flake update`
+        # is what pulls in the newest theme set.
         vogix16-themes.url = "github:i-am-logger/vogix16-themes";
         rust-overlay.follows = "lanzaboote/rust-overlay";
         devenv.inputs.git-hooks.follows = "git-hooks";

--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,9 @@
         nixpkgs.follows = "nixpkgs";
         home-manager.follows = "home-manager";
         tinted-schemes.url = "github:i-am-logger/tinted-schemes";
+        # Track vogix16-themes directly (vogix's own lock can lag its releases),
+        # so mynixos always builds against the latest theme set.
+        vogix16-themes.url = "github:i-am-logger/vogix16-themes";
         rust-overlay.follows = "lanzaboote/rust-overlay";
         devenv.inputs.git-hooks.follows = "git-hooks";
       };
@@ -55,11 +58,7 @@
       url = "github:nix-community/lanzaboote";
       inputs = {
         nixpkgs.follows = "nixpkgs";
-        pre-commit.inputs = {
-          nixpkgs.follows = "nixpkgs";
-          flake-compat.follows = "vogix/crate2nix/flake-compat";
-          gitignore.follows = "vogix/crate2nix/pre-commit-hooks/gitignore";
-        };
+        pre-commit.inputs.nixpkgs.follows = "nixpkgs";
       };
     };
 

--- a/my/hardware/motherboards/gigabyte/x870e-aorus-elite-wifi7/default.nix
+++ b/my/hardware/motherboards/gigabyte/x870e-aorus-elite-wifi7/default.nix
@@ -19,6 +19,11 @@ in
     # `my.hardware.gpu = "amd"` set below).
     (mkIf cfg.enable (import ./drivers/amd-integrated-gpu.nix { inherit config lib pkgs; }))
 
+    # GPU-fault forensics: capture the amdgpu devcoredump (the faulting shader,
+    # which the kernel deletes after ~5 min) + persistent journald, so a
+    # recurrence of the web-triggered iGPU reset is diagnosable to root cause.
+    (mkIf cfg.enable (import ./drivers/amd-gpu-forensics.nix { inherit config lib pkgs; }))
+
     # Platform architecture (conditionally)
     (mkIf cfg.enable {
       nixpkgs.hostPlatform = mkDefault "x86_64-linux";

--- a/my/hardware/motherboards/gigabyte/x870e-aorus-elite-wifi7/drivers/amd-gpu-forensics.nix
+++ b/my/hardware/motherboards/gigabyte/x870e-aorus-elite-wifi7/drivers/amd-gpu-forensics.nix
@@ -1,0 +1,72 @@
+{ pkgs, ... }:
+
+# AMD iGPU GPU-fault forensics for this Raphael (gfx10.3.6 / RDNA2) host.
+#
+# Context: a web page (Brave's GPU process) can issue a shader that triggers a
+# GCVM_L2_PROTECTION_FAULT -> `ring gfx_0.1.0` timeout -> full MODE2 GPU reset,
+# which Hyprland does not survive (it RASSERT-aborts in CHyprOpenGLImpl::begin,
+# hyprwm/Hyprland#9746). This module does NOT mitigate the crash and removes no
+# feature; it makes the NEXT occurrence diagnosable to ROOT CAUSE by preserving
+# the two highest-value artifacts, both of which were LOST in the 2026-06-14
+# event:
+#
+#   1. the amdgpu *devcoredump* — the faulting shader / IB disassembly — which
+#      the kernel auto-expires ~5 min after creation; copied here to
+#      /var/log/gpu-forensics before it disappears; and
+#   2. a *persistent* journal (kernel amdgpu fault block + Brave's GPU-process
+#      log), so the evidence survives the reboot that usually follows the
+#      session-killing reset.
+#
+# /var/log and /var/lib/systemd (systemd-coredump) are already in the
+# impermanence persistence set (my/storage/impermanence/impermanence.nix), so
+# both the captures and the process coredumps survive reboots with no extra
+# persistence wiring.
+
+let
+  # Copy a devcoredump out before the kernel reclaims it, then release it.
+  captureDevcoredump = pkgs.writeShellScript "amdgpu-devcoredump-capture" ''
+    set -euo pipefail
+    inst="''${1:?usage: amdgpu-devcoredump-capture <devcdN>}"
+    src="/sys/class/devcoredump/''${inst}/data"
+    outdir="/var/log/gpu-forensics"
+    out="''${outdir}/amdgpu-devcoredump-$(${pkgs.coreutils}/bin/date +%Y%m%d-%H%M%S)-''${inst}.bin"
+    ${pkgs.coreutils}/bin/mkdir -p "''${outdir}"
+    if [ -r "''${src}" ]; then
+      ${pkgs.coreutils}/bin/cp "''${src}" "''${out}"
+      echo "amdgpu-devcoredump: captured ''${src} -> ''${out} ($(${pkgs.coreutils}/bin/stat -c %s "''${out}") bytes)"
+      # We have a copy; free the kernel dump promptly (it would otherwise linger
+      # ~5 min, pinning GPU-dump memory).
+      echo 1 > "''${src}" || true
+    else
+      echo "amdgpu-devcoredump: ''${src} not readable; nothing captured" >&2
+    fi
+  '';
+in
+{
+  # Capture every device coredump the instant the kernel creates one. amdgpu
+  # raises one on each GPU recovery; the RUN+= only kicks off a --no-block unit,
+  # so the udev event itself stays short.
+  services.udev.extraRules = ''
+    SUBSYSTEM=="devcoredump", ACTION=="add", RUN+="${pkgs.systemd}/bin/systemctl --no-block start amdgpu-devcoredump-capture@%k.service"
+  '';
+
+  systemd.services."amdgpu-devcoredump-capture@" = {
+    description = "Capture amdgpu devcoredump %i before kernel auto-expiry";
+    serviceConfig = {
+      Type = "oneshot";
+      ExecStart = "${captureDevcoredump} %i";
+    };
+  };
+
+  systemd.tmpfiles.rules = [
+    "d /var/log/gpu-forensics 0750 root root -"
+  ];
+
+  # Retain the journal (kernel amdgpu fault + Brave GPU-process log) across the
+  # reboot that typically follows a session-killing GPU reset. /var/log is
+  # already persisted, so this just forces journald to write there.
+  services.journald.extraConfig = ''
+    Storage=persistent
+    SystemMaxUse=2G
+  '';
+}

--- a/my/hardware/motherboards/gigabyte/x870e-aorus-elite-wifi7/drivers/amd-gpu-forensics.nix
+++ b/my/hardware/motherboards/gigabyte/x870e-aorus-elite-wifi7/drivers/amd-gpu-forensics.nix
@@ -28,6 +28,15 @@ let
     set -euo pipefail
     inst="''${1:?usage: amdgpu-devcoredump-capture <devcdN>}"
     src="/sys/class/devcoredump/''${inst}/data"
+    # The devcoredump udev rule fires for EVERY driver's dump, but this unit is
+    # amdgpu-specific. Resolve the failing device's driver and skip anything that
+    # is a known non-amdgpu driver. An undetermined driver is still captured —
+    # better to keep evidence than miss the amdgpu dump we are here for.
+    drv="$(${pkgs.coreutils}/bin/basename "$(${pkgs.coreutils}/bin/readlink -f "/sys/class/devcoredump/''${inst}/failing_device/driver" 2>/dev/null)" 2>/dev/null || echo unknown)"
+    if [ "''${drv}" != "amdgpu" ] && [ "''${drv}" != "unknown" ]; then
+      echo "amdgpu-devcoredump: ''${inst} is from driver ''${drv}, not amdgpu; skipping" >&2
+      exit 0
+    fi
     outdir="/var/log/gpu-forensics"
     out="''${outdir}/amdgpu-devcoredump-$(${pkgs.coreutils}/bin/date +%Y%m%d-%H%M%S)-''${inst}.bin"
     ${pkgs.coreutils}/bin/mkdir -p "''${outdir}"

--- a/my/hardware/peripherals/elgato/streamdeck/default.nix
+++ b/my/hardware/peripherals/elgato/streamdeck/default.nix
@@ -265,7 +265,7 @@ in
           home.packages = with pkgs; [
             streamdeck-ui
             # Qt platform dependencies
-            libsForQt5.qt5.qtwayland
+            qt5.qtwayland
             qt6.qtwayland
             # Audio utilities (already have pamixer from your config)
             pamixer
@@ -364,7 +364,7 @@ in
     # Fix Qt platform plugin issues for streamdeck-ui
     environment.sessionVariables = {
       # Set Qt platform plugins path
-      QT_QPA_PLATFORM_PLUGIN_PATH = "${pkgs.libsForQt5.qt5.qtbase.bin}/lib/qt-${pkgs.libsForQt5.qt5.qtbase.version}/plugins/platforms:${pkgs.qt6.qtbase}/lib/qt-6/plugins/platforms";
+      QT_QPA_PLATFORM_PLUGIN_PATH = "${pkgs.qt5.qtbase.bin}/lib/qt-${pkgs.qt5.qtbase.version}/plugins/platforms:${pkgs.qt6.qtbase}/lib/qt-6/plugins/platforms";
       # Prefer Wayland but fallback to xcb
       QT_QPA_PLATFORM = "wayland;xcb";
       # Enable Qt logging for debugging

--- a/my/security/default.nix
+++ b/my/security/default.nix
@@ -16,7 +16,8 @@ in
     # Secure Boot configuration
     (mkIf (cfg.enable && cfg.secureBoot.enable) {
       boot = {
-        bootspec.enable = true;
+        # bootspec is always generated in current nixpkgs (the enable option was
+        # removed); lanzaboote consumes it automatically.
         lanzaboote = {
           enable = true;
           pkiBundle = "/var/lib/sbctl";

--- a/my/users/apps/browsers/brave/default.nix
+++ b/my/users/apps/browsers/brave/default.nix
@@ -18,12 +18,21 @@ with lib;
                 name = "brave-with-gopass";
                 paths = [ pkgs.brave ];
                 nativeBuildInputs = [ pkgs.makeWrapper ];
+                # GPU-fault forensics (Raphael iGPU reset incident, 2026-06):
+                # route Brave's GPU process + GL driver logs to stderr so a
+                # future web-triggered amdgpu shader fault is diagnosable from
+                # the (now persistent) journal. See the x870e
+                # drivers/amd-gpu-forensics.nix module for the matching journald
+                # persistence + devcoredump capture.
                 postBuild = ''
                   wrapProgram $out/bin/brave \
                     --add-flags "--password-store=basic" \
                     --add-flags "--disable-password-manager" \
                     --add-flags "--enable-features=UseOzonePlatform" \
                     --add-flags "--ozone-platform=wayland" \
+                    --add-flags "--enable-logging=stderr" \
+                    --add-flags "--enable-gpu-driver-debug-logging" \
+                    --add-flags "--vmodule=*gpu*=2,*command_buffer*=2,*gl_context*=1,*shared_image*=1,*webgl*=1" \
                     --set GNOME_KEYRING_CONTROL "" \
                     --set DISABLE_GNOME_KEYRING "1" \
                     --set SSH_AUTH_SOCK "$(gpgconf --list-dirs agent-ssh-socket)"


### PR DESCRIPTION
Brings the system current with the freshly-released **vogix v0.8.0** plus the nixpkgs bump's fallout.

Commits:
- `fix(nixpkgs)`: drop `boot.bootspec.enable` (removed) and `libsForQt5.qt5.*` → `qt5.*` (streamdeck module) — required for the nixpkgs bump to evaluate.
- `chore(flake)`: track vogix16-themes directly; drop the dangling `vogix/crate2nix` follows. (Also carries two in-flight WIP files: the gigabyte x870e motherboard import and a brave tweak.)
- `build(deps)`: bump vogix `v0.7.0` → `v0.8.0` — the variant-nav rework + docs↔code audit fixes (incl. the home-manager login `vogix theme refresh` fix and the atomic theme-symlink swap).

`nix eval` of `nixosConfigurations.yoga` is clean → `mynixos-system-yoga-0.11.0.drv`.