### PR TITLE
ci(deps): bump GitHub Actions to latest

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -24,9 +24,9 @@ jobs:
       )
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v17
+        uses: DeterminateSystems/nix-installer-action@v22
         with:
           extra-conf: |
             extra-substituters = https://nix-community.cachix.org https://cache.nixos.org
@@ -43,9 +43,9 @@ jobs:
       )
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v17
+        uses: DeterminateSystems/nix-installer-action@v22
       - name: Run statix
         run: nix run nixpkgs#statix -- check .
       - name: Run deadnix
@@ -61,11 +61,11 @@ jobs:
       )
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Generate module coverage report
         run: bash scripts/module-coverage.sh --lcov
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           files: coverage.lcov
           flags: modules
@@ -87,7 +87,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Bumps GitHub Actions to their latest releases.

| action | old → new |
|---|---|
| actions/checkout | v6 → v7 |
| DeterminateSystems/nix-installer-action | v17 → v22 |
| codecov/codecov-action | v5 → v7 |
| googleapis/release-please-action | v4 → v5 |

CI on this PR exercises checkout / nix-installer / codecov; release-please-action runs on master push (v5 = node24 runtime only, no config/behaviour change). `actionlint` clean.