### PR TITLE
feat(system): build the kernel from a local source tree

### DIFF
--- a/my/system/kernel/default.nix
+++ b/my/system/kernel/default.nix
@@ -46,11 +46,14 @@ in
       boot.kernelPackages = kernelFromSource;
     })
     (mkIf (ls == null) {
-      boot.kernelPackages = mkDefault (
+      # `package` (when set) at NORMAL priority so it overrides a hardware
+      # module's mkDefault kernel (e.g. the Legion's mkDefault linuxPackages_latest
+      # in legion-16irx8h/drivers/uefi-boot.nix); only the fallback is mkDefault,
+      # so hardware may still pick a default. A host mkForce still wins over both.
+      boot.kernelPackages =
         if cfg.kernel.package != null
         then cfg.kernel.package
-        else pkgs.linuxPackages_latest # mynixos default
-      );
+        else mkDefault pkgs.linuxPackages_latest; # mynixos default
     })
 
     # Architecture configuration (auto-detected from hardware, can be overridden)

--- a/my/system/kernel/default.nix
+++ b/my/system/kernel/default.nix
@@ -4,6 +4,25 @@ with lib;
 
 let
   cfg = config.my.system;
+  ls = cfg.kernel.localSource;
+
+  # Build a kernel package set from a local source tree by overriding a nixpkgs
+  # mainline kernel. `argsOverride` is the ONLY channel that reaches buildLinux's
+  # src/version/modDirVersion (mainline.nix computes those internally and merges
+  # argsOverride last, so a top-level `.override { src = ...; version = ...; }` is
+  # silently ignored). common-config.nix still regenerates the NixOS-required
+  # config, parameterized by `version`, so no .config file is maintained by hand.
+  kernelFromSource =
+    let
+      base = if ls.base != null then ls.base else pkgs.linux_latest;
+      kernel = base.override {
+        argsOverride = {
+          inherit (ls) src version;
+          modDirVersion = if ls.modDirVersion != null then ls.modDirVersion else ls.version;
+        };
+      };
+    in
+    pkgs.linuxPackagesFor kernel;
 in
 {
   config = mkMerge [
@@ -15,17 +34,24 @@ in
       );
     }
 
-    # Kernel configuration
-    # Default: linuxPackages_latest (mynixos opinionated default)
-    # Hardware modules may override with mkDefault
-    # Users can override by setting my.system.kernel = pkgs.linuxPackages_X_XX
-    {
+    # Kernel configuration.
+    # Precedence: localSource (build from a local tree) > package override >
+    # mynixos default (linuxPackages_latest). The localSource branch assigns at
+    # normal priority so it beats hardware mkDefault overrides while remaining
+    # host-mkForce-overridable. NixOS's boot.kernelPackages `apply` still appends
+    # config.boot.kernelPatches on top of the source build (e.g. KUnit config).
+    # Use mkIf (deferred), NOT a bare if/else on `ls`: branching the module's
+    # config structure on a config value triggers infinite recursion.
+    (mkIf (ls != null) {
+      boot.kernelPackages = kernelFromSource;
+    })
+    (mkIf (ls == null) {
       boot.kernelPackages = mkDefault (
-        if cfg.kernel != null
-        then cfg.kernel
+        if cfg.kernel.package != null
+        then cfg.kernel.package
         else pkgs.linuxPackages_latest # mynixos default
       );
-    }
+    })
 
     # Architecture configuration (auto-detected from hardware, can be overridden)
     (mkIf (cfg.architecture != null) {

--- a/my/system/options.nix
+++ b/my/system/options.nix
@@ -13,9 +13,44 @@
         };
 
         kernel = lib.mkOption {
-          type = lib.types.nullOr lib.types.package;
-          default = null;
-          description = "Kernel package override (e.g., pkgs.linuxPackages_latest, pkgs.linuxPackages_6_12). If null, uses hardware module default (typically latest).";
+          description = "Kernel selection: override the packaged kernel set, or build boot.kernelPackages from a local source tree.";
+          default = { };
+          type = lib.types.submodule {
+            options = {
+              package = lib.mkOption {
+                type = lib.types.nullOr lib.types.package;
+                default = null;
+                description = "Kernel packages override (e.g. pkgs.linuxPackages_latest, pkgs.linuxPackages_6_12). If null (and localSource is unset) the mynixos default (linuxPackages_latest) is used; hardware modules may mkDefault-override boot.kernelPackages.";
+              };
+
+              localSource = lib.mkOption {
+                default = null;
+                description = "Build boot.kernelPackages from a local kernel source tree instead of a packaged kernel. Takes precedence over `package`. Intended for a checked-out git tree exposed as a `flake = false` git+file input (copies tracked files only). mynixos overrides a nixpkgs mainline kernel's src/version so NixOS kernel-config generation and boot.kernelPatches still apply to the source build.";
+                type = lib.types.nullOr (lib.types.submodule {
+                  options = {
+                    src = lib.mkOption {
+                      type = lib.types.path;
+                      description = "Kernel source tree (must contain the top-level Makefile); e.g. the outPath of a `flake = false` source input.";
+                    };
+                    version = lib.mkOption {
+                      type = lib.types.str;
+                      description = "Upstream version of the tree, e.g. \"7.1.0\". MUST equal the tree's Makefile VERSION.PATCHLEVEL.SUBLEVEL, otherwise a /lib/modules modDirVersion mismatch hard-fails the build.";
+                    };
+                    modDirVersion = lib.mkOption {
+                      type = lib.types.nullOr lib.types.str;
+                      default = null;
+                      description = "Module directory version = `make kernelrelease` = include/config/kernel.release. Defaults to `version`; set explicitly only if the tree appends a LOCALVERSION/`+` suffix.";
+                    };
+                    base = lib.mkOption {
+                      type = lib.types.nullOr lib.types.package;
+                      default = null;
+                      description = "nixpkgs mainline kernel whose config baseline to override (e.g. pkgs.linux_7_1). Pin it to the source's series so a future nixpkgs `latest` bump does not shift the common-config baseline. If null, uses pkgs.linux_latest.";
+                    };
+                  };
+                });
+              };
+            };
+          };
         };
 
         architecture = lib.mkOption {

--- a/my/system/options.nix
+++ b/my/system/options.nix
@@ -20,7 +20,7 @@
               package = lib.mkOption {
                 type = lib.types.nullOr lib.types.package;
                 default = null;
-                description = "Kernel packages override (e.g. pkgs.linuxPackages_latest, pkgs.linuxPackages_6_12). If null (and localSource is unset) the mynixos default (linuxPackages_latest) is used; hardware modules may mkDefault-override boot.kernelPackages.";
+                description = "Kernel packages override (e.g. pkgs.linuxPackages_latest, pkgs.linuxPackages_6_12). When set, assigned at normal priority so it overrides a hardware module's mkDefault kernel (a host mkForce still wins). If null (and localSource is unset) the mynixos default (linuxPackages_latest) is used at mkDefault, which hardware may override.";
               };
 
               localSource = lib.mkOption {


### PR DESCRIPTION
## What

Add `my.system.kernel.localSource` — build `boot.kernelPackages` from a local
kernel source tree instead of a packaged kernel.

`my.system.kernel` is promoted from `nullOr package` to a submodule:

- `package` — the previous override (e.g. `pkgs.linuxPackages_6_12`).
- `localSource` — `{ src; version; modDirVersion?; base?; }`. When set, builds
  the kernel from `src` by overriding a nixpkgs mainline kernel's `src`/`version`
  via `argsOverride` (the only channel that reaches `buildLinux`), piped to
  `linuxPackagesFor`. NixOS kernel-config generation and `boot.kernelPatches`
  still compose on top — no hand-maintained `.config`.

## Why

Lets a host build and iterate on a checked-out kernel branch (git-tracked)
instead of exporting/applying `.patch` files that break on every kernel bump.
Intended for a `flake = false` `git+file` input (copies tracked files only).

## Notes

- **Breaking** (mynixos is unstable API): `my.system.kernel = pkgs.linuxPackages_X`
  becomes `my.system.kernel.package = ...`. Nothing in the tree used the scalar form.
- `modDirVersion` must equal the tree's `make kernelrelease` (a plain `7.1.0`
  Makefile tree → `"7.1.0"`, not nixpkgs' `7.1.2`), or `build.nix` hard-fails.
- The impl branches with `mkIf`, not a bare `if/else` on a config value (which
  triggers infinite recursion in module structure evaluation).

## Verified

- `statix check` and `deadnix` clean.
- Exercised end-to-end from a consuming host: `boot.kernelPackages` built from a
  local `7.1.0` branch — the kernel compiles and the full system toplevel assembles.
