### PR TITLE
feat(git): add glab and gitlab.com SSH URL rewrite

### DIFF
--- a/my/users/apps/git/default.nix
+++ b/my/users/apps/git/default.nix
@@ -8,6 +8,7 @@ with lib;
       (_name: userCfg: {
         home.packages = with pkgs; [
           gh
+          glab
           lazygit
         ];
 
@@ -37,6 +38,7 @@ with lib;
 
             # Opinionated config
             url."git@github.com:".insteadOf = "https://github.com/";
+            url."git@gitlab.com:".insteadOf = "https://gitlab.com/";
             core.editor = "hx";
           };
 


### PR DESCRIPTION
Adds the GitLab CLI (`glab`) alongside `gh`/`lazygit`, and mirrors the existing
`git@github.com` insteadOf rewrite for `gitlab.com`, so `https://gitlab.com/...`
remotes resolve over SSH.

The `gitlab.com` SSH host block already exists in the ssh module
(`IdentitiesOnly = no` for YubiKey users), so YubiKey auth to gitlab.com works with
no further changes — this only adds the CLI and the URL rewrite.

Motivation: contributing to GitLab-hosted projects (e.g. OpenRGB, which is
GitLab-primary) from the terminal.
