### PR TITLE
fix(wezterm): repair line editing, window sizing and transparency on macOS

### DIFF
--- a/my/users/apps/terminals/wezterm/default.nix
+++ b/my/users/apps/terminals/wezterm/default.nix
@@ -2,6 +2,11 @@
 
 with lib;
 
+let
+  # Same option on both platforms, different interior: the module is shared, so
+  # the platform is read here rather than expressed by file placement.
+  inherit (pkgs.stdenv.hostPlatform) isDarwin;
+in
 {
   config = {
 
@@ -39,13 +44,49 @@ with lib;
 
                 -- Terminal settings
                 config.enable_wayland = true
+
                 config.window_background_opacity = 0.70
+
+                -- Transparency is only legible when something blurs what shows
+                -- through. On Linux the compositor does that pass, so opacity
+                -- alone is enough; macOS has no equivalent, and the same 0.70
+                -- reads as plain see-through over whatever is behind the window.
+                --
+                -- wezterm draws its own surface with wgpu and adopts no AppKit
+                -- materials, so the system Liquid Glass look is not available to
+                -- it. This is the native blur it does expose.
+                ${optionalString isDarwin "config.macos_window_background_blur = 30"}
                 config.hide_tab_bar_if_only_one_tab = true
                 config.default_cursor_style = 'BlinkingBlock'
                 config.cursor_blink_rate = 200
                 config.cursor_thickness = 1
                 config.window_close_confirmation = 'NeverPrompt'
+
+                -- Ctrl+= / Ctrl+- change how much fits in the window, not how
+                -- big the window is. The default holds rows x columns fixed and
+                -- resizes the window to match the new cell size, which moves and
+                -- rescales the window every time the font changes.
+                config.adjust_window_size_when_changing_font_size = false
                 config.term = 'wezterm'
+                ${optionalString isDarwin ''
+                  -- TERM=wezterm is only usable if the shell can resolve that
+                  -- terminfo entry AT STARTUP. On macOS wezterm is launched by
+                  -- LaunchServices, whose environment has no TERMINFO_DIRS, so
+                  -- zsh looks the terminal up before /etc/zshenv can set one,
+                  -- fails, and DISABLES ZLE -- which breaks line editing: with no
+                  -- cursor control, syntax highlighting redraws append instead of
+                  -- overwrite and typed characters appear duplicated. ncurses
+                  -- caches that first failure, so setting the variable later in
+                  -- shell startup does not repair it.
+                  --
+                  -- Naming the terminfo package directly rather than a profile
+                  -- keeps this correct for root and for any shell, not just an
+                  -- interactive login one. Linux needs none of this: the system
+                  -- profile aggregates terminfo and the lookup already succeeds.
+                  config.set_environment_variables = {
+                    TERMINFO_DIRS = '${pkgs.wezterm.terminfo}/share/terminfo:/usr/share/terminfo',
+                  }
+                ''}
                 config.check_for_updates = false
 
                 -- Vogix theme colors (live-reloaded on theme switch via SIGUSR1)


### PR DESCRIPTION
Three wezterm defects on macOS, all found by using the Mac after the first activation. Verified fixed on `aether5d-dev`.

## Line editing was broken

Typing one character could insert several, and `clear` left the previous screen behind.

`TERM=wezterm` is only usable if the shell can resolve that terminfo entry **at startup**. On macOS wezterm is launched by LaunchServices, whose environment carries no `TERMINFO_DIRS`, so zsh looks the terminal up before `/etc/zshenv` can set one, fails, and **disables ZLE**. With no cursor control, zsh-syntax-highlighting's redraw appends instead of overwriting — typing `clear` rendered as `clearaar`. ncurses caches that first failure, which is why the `TERMINFO_DIRS` assignments later in shell startup don't repair it and instead just reprint:

```
set-environment:8: can't find terminal definition for wezterm
set-environment:17: can't find terminal definition for wezterm
hm-session-vars.sh:16: can't find terminal definition for wezterm
hm-session-vars.sh:25: can't find terminal definition for wezterm
```

wezterm now puts the variable in the pty environment itself via `set_environment_variables`, naming the terminfo **package** directly rather than a profile, so it is equally correct for root and for non-login shells. Linux needs none of it — the system profile aggregates terminfo and the lookup already succeeds.

Two plausible theories were checked and rejected rather than shipped: the terminfo directory layout is not at fault (nix and macOS both use hex dirs, `77/wezterm`), and Apple's `libncurses.5.4` does honour `TERMINFO_DIRS`.

## Window resized on every font-size change

`adjust_window_size_when_changing_font_size` defaults to true, holding rows × columns fixed and resizing the *window* to match the new cell size. False inverts it, which is what the shortcut is for.

## Transparency had nothing to blur

On Linux the compositor does the blur pass, so opacity alone is enough; macOS has no equivalent and the same `0.70` reads as plain see-through. `macos_window_background_blur = 30` is the native blur wezterm exposes. (wezterm draws its own surface with wgpu and adopts no AppKit materials — it references neither `NSVisualEffectView` nor `NSGlassEffectView` — so the system Liquid Glass material is not available to it.)

## Verification

- Reproduced the terminfo failure with an interactive `zsh -i`, and confirmed presetting `TERMINFO_DIRS` eliminates it.
- Generated `wezterm.lua` parses under `luac -p`, with exactly one `return config`.
- Blur and the environment block appear on darwin only; yoga has zero occurrences and its `window_background_opacity` is unchanged at 0.70.
- statix and deadnix clean; 121/121 checks pass.
- Running on `aether5d-dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T466QuHzdfzF7YmeGCoJoz
