### PR TITLE
feat(apps): herdr as the default multiplexer, discord per platform

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -31,25 +31,32 @@ jobs:
           extra-conf: |
             extra-substituters = https://nix-community.cachix.org https://cache.nixos.org
             extra-trusted-public-keys = nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+      # The whole check suite -- ~125 evaluations plus every dev shell input --
+      # was rebuilt from cache.nixos.org on every run.
+      - name: Restore and save the Nix store
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', 'flake.lock') }}
+          # No lock hash in the prefix, so a lockfile bump still restores the
+          # previous store and builds only the delta.
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          # Restore everywhere, save only on master. GitHub caches are
+          # ref-scoped: a PR reads master's entry but writes its own, so an
+          # ungated save spends the repo's budget once per open PR and evicts
+          # the entry everything else restores from.
+          save: ${{ github.ref == 'refs/heads/master' }}
+          purge: ${{ github.ref == 'refs/heads/master' }}
+          purge-prefixes: nix-${{ runner.os }}-
+          purge-created: 0
+          purge-primary-key: never
+          gc-max-store-size-linux: 8G
+      # statix and deadnix are NOT a separate job any more. They are treefmt
+      # programs now (treefmt.nix), so `nix flake check`'s `formatting` check
+      # runs them -- which means `nix fmt` locally and CI can no longer disagree
+      # about whether the tree is clean. A separate job could only ever drift
+      # from what `nix fmt` does.
       - name: Run nix flake check
         run: nix flake check --print-build-logs
-  nix-lint:
-    name: Nix Lint (statix + deadnix)
-    runs-on: ubuntu-latest
-    if: |
-      !(
-        (github.event_name == 'pull_request' && startsWith(github.event.pull_request.title, 'chore(master): release')) ||
-        (github.event_name == 'push' && contains(github.event.head_commit.message, 'release-please--branches--master'))
-      )
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v22
-      - name: Run statix
-        run: nix run nixpkgs#statix -- check .
-      - name: Run deadnix
-        run: nix run nixpkgs#deadnix -- --fail .
   module-coverage:
     name: Module Coverage
     runs-on: ubuntu-latest
@@ -74,7 +81,7 @@ jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
-    needs: [nix-flake-check, nix-lint, module-coverage]
+    needs: [nix-flake-check, module-coverage]
     # always() prevents auto-skip when dependencies are skipped (release merges)
     # Then check: either CI passed or was skipped (release-please commits skip CI)
     if: |

--- a/my/users/apps/communication/discord/darwin.nix
+++ b/my/users/apps/communication/discord/darwin.nix
@@ -1,0 +1,59 @@
+# Discord on macOS: a Homebrew cask, not the nixpkgs derivation.
+#
+# This is a deliberate exception to "everything else should be a derivation",
+# and the reason is measurable rather than a matter of taste. nixpkgs stages
+# Discord's fifteen native modules INSIDE the signed app bundle, at
+# Contents/Resources/modules/. Those files were not present when Discord, Inc.
+# signed and notarised the bundle, so the seal no longer holds:
+#
+#   $ codesign --verify --strict <store-path>/Applications/Discord.app
+#   a sealed resource is missing or invalid
+#   file added: .../Contents/Resources/modules/discord_rpc/index.js
+#
+# macOS then refuses to launch it outright -- "Discord is damaged and can't be
+# opened" -- and, because the bundle has no valid identity, it also cannot be
+# recognised as com.hnc.Discord for the purposes of reaching its own data in
+# ~/Library/Application Support/discord, which macOS protects per-app.
+#
+# The CLI wrapper fails separately and for a related reason: it runs a
+# pre-launch helper under a Nix-store python3, which is a different program
+# reaching into another app's protected directory, so TCC denies it with EPERM.
+# The wrapper is `bash -e`, so that non-zero exit aborts before the exec.
+#
+# None of this is fixable downstream: any modification to the bundle breaks the
+# seal, and staging the modules is how the package works. The cask installs
+# Discord's own signed, notarised build, which launches and keeps its identity.
+#
+# Only the INSTALL is managed. The cask is auto_updates, so Discord updates
+# itself -- which is what it does regardless, and the reason nixpkgs carries a
+# "disable breaking updates" patch at all.
+#
+# Imported only by platforms/darwin.nix.
+{ config, lib, ... }:
+
+with lib;
+
+let
+  anyUserDiscord = any
+    (userCfg: userCfg.apps.communication.messaging.discord.enable or false)
+    (attrValues config.my.users);
+in
+{
+  config = mkIf anyUserDiscord {
+    my.homebrew.casks = [ "discord" ];
+
+    # Without Homebrew there is nothing to install into, and the app would just
+    # silently not appear. Say so instead.
+    assertions = [
+      {
+        assertion = config.my.homebrew.enable;
+        message = ''
+          my.users.<name>.apps.communication.messaging.discord is enabled, but
+          my.homebrew.enable is false. Discord on darwin is a Homebrew cask --
+          see my/users/apps/communication/discord/darwin.nix for why it cannot
+          be the nixpkgs derivation.
+        '';
+      }
+    ];
+  };
+}

--- a/my/users/apps/communication/discord/default.nix
+++ b/my/users/apps/communication/discord/default.nix
@@ -1,0 +1,16 @@
+# Discord on Linux: the nixpkgs derivation, like any other app.
+#
+# The option is declared in ./options.nix rather than in this spec, because
+# ./darwin.nix implements the same option a completely different way. See there
+# for why macOS cannot use this derivation.
+#
+# Imported only by platforms/linux.nix.
+args:
+
+(import ../../../../../lib/mk-app.nix).mkApp args {
+  path = "communication.messaging.discord";
+  unfree = [ "discord" ];
+  home = { pkgs, ... }: {
+    home.packages = [ pkgs.discord ];
+  };
+}

--- a/my/users/apps/communication/discord/options.nix
+++ b/my/users/apps/communication/discord/options.nix
@@ -1,0 +1,25 @@
+# Discord's option, declared beside its implementation rather than carried in a
+# mkApp spec -- because there are two implementations and neither can own an
+# option the other platform also needs: ./default.nix installs the nixpkgs
+# derivation on Linux, ./darwin.nix declares a Homebrew cask on macOS. Same
+# shape, and the same reason, as my/users/apps/security/1password/options.nix.
+{ lib, ... }:
+
+let
+  appLib = import ../../../../../lib/app-options.nix { inherit lib; };
+in
+{
+  options.my.users = lib.mkOption {
+    type = lib.types.attrsOf (lib.types.submodule {
+      options.apps.communication.messaging.discord = appLib.mkAppOption {
+        name = "Discord";
+        default = false;
+        description = "Discord voice and text chat";
+        # Linux only in effect: macOS keeps its state in
+        # ~/Library/Application Support/discord, and no darwin host runs
+        # impermanence.
+        persistedDirectories = [ ".config/discord" ];
+      };
+    });
+  };
+}

--- a/my/users/apps/git/default.nix
+++ b/my/users/apps/git/default.nix
@@ -2,6 +2,29 @@
 
 with lib;
 
+let
+  # See ./options.nix. "ssh" rewrites forge URLs to their SSH form; "https"
+  # leaves them alone and hands authentication to the forge CLI, which already
+  # holds a token. The two are exclusive — a host does one or the other.
+  transport = userCfg:
+    if userCfg.apps.dev.tools.git.protocol == "ssh" then {
+      # The same three hosts my/users/apps/ssh gives a Host block to. The https
+      # branch covers only two: bitbucket has no packaged CLI holding a token,
+      # so there is nothing to install as a helper -- see ./options.nix.
+      #
+      # One `url` attrset rather than three `url.<x>` lines: statix's
+      # repeated_keys fires at three, and the pre-commit statix hook CHECKS
+      # rather than fixes, so treefmt cannot paper over it.
+      url = {
+        "git@github.com:".insteadOf = "https://github.com/";
+        "git@gitlab.com:".insteadOf = "https://gitlab.com/";
+        "git@bitbucket.org:".insteadOf = "https://bitbucket.org/";
+      };
+    } else {
+      credential."https://github.com".helper = "!${pkgs.gh}/bin/gh auth git-credential";
+      credential."https://gitlab.com".helper = "!${pkgs.glab}/bin/glab auth git-credential";
+    };
+in
 {
   config = {
     home-manager.users = mapAttrs
@@ -40,10 +63,8 @@ with lib;
             merge.conflictstyle = "zdiff3"; # show the common ancestor in conflicts
             diff.colorMoved = "default"; # distinguish moved lines from added/removed
 
-            url."git@github.com:".insteadOf = "https://github.com/";
-            url."git@gitlab.com:".insteadOf = "https://gitlab.com/";
             core.editor = "hx";
-          };
+          } // transport userCfg;
 
           # Opinionated ignores
           ignores = [

--- a/my/users/apps/git/options.nix
+++ b/my/users/apps/git/options.nix
@@ -1,0 +1,42 @@
+# Git forge transport.
+#
+# Declared beside ./default.nix, the only thing that reads it. Not an mkApp
+# module — git is always on and has no `enable` — so the option lives in this
+# sibling file, the same shape claude-code and 1password use.
+#
+# Common, and deliberately not a platform split: which transport works is a fact
+# about the CREDENTIAL a host holds, not about its kernel. yoga and skyspy-dev
+# answer to a YubiKey over SSH; aether5d-dev answers to a gh token over HTTPS.
+# A darwin host with a provisioned Secure Enclave key would want "ssh" again, and
+# stating it per host is what lets it.
+{ lib, ... }:
+
+{
+  options.my.users = lib.mkOption {
+    type = lib.types.attrsOf (lib.types.submodule {
+      options.apps.dev.tools.git.protocol = lib.mkOption {
+        type = lib.types.enum [ "ssh" "https" ];
+        default = "ssh";
+        description = ''
+          How git reaches the forges.
+
+          "ssh" rewrites `https://` forge URLs to their SSH form, so a URL
+          written down anywhere — a `cloneConfigRepo`, a README, a `go get` —
+          authenticates with an agent-held key instead of asking for a password.
+          This covers github.com, gitlab.com and bitbucket.org, matching the
+          three hosts my/users/apps/ssh configures.
+
+          "https" leaves URLs alone and installs the forge CLI as git's
+          credential helper, so the token `gh`/`glab` already holds is what
+          authenticates. Use this on a host with no SSH identity the forge
+          accepts.
+
+          The two modes deliberately cover different sets. bitbucket.org has no
+          packaged CLI holding a token, so under "https" it gets no helper from
+          here and falls back to git's own credential store — which is the
+          honest outcome, not an oversight.
+        '';
+      };
+    });
+  };
+}

--- a/my/users/apps/multiplexers/herdr/default.nix
+++ b/my/users/apps/multiplexers/herdr/default.nix
@@ -1,0 +1,76 @@
+# herdr, a terminal multiplexer built around running coding agents side by side.
+#
+# Gated on `terminal.multiplexer == "herdr"`, the same selector tmux and zellij
+# use, and for the same reason: a second on/off switch beside the selector is a
+# second way to say one thing. Its enum member and the enum's default are
+# declared in ./options.nix.
+#
+# Unlike tmux and zellij, home-manager has no programs.herdr module, so this one
+# puts the package on PATH and writes the config file itself.
+{ activeUsers, config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  isHerdr = userCfg: (userCfg.terminal.multiplexer or null) == "herdr";
+
+  # `herdr --default-config` is the schema of record. Only settings that would
+  # otherwise be WRONG for a Nix-managed install are stated; herdr's own
+  # defaults are left unsaid.
+  settingsFor = userCfg: {
+    # A declarative install has already made every choice the wizard asks about.
+    onboarding = false;
+
+    theme = {
+      # Follow the host terminal's light/dark appearance rather than pinning one.
+      auto_switch = true;
+      dark_name = "catppuccin";
+      light_name = "catppuccin-latte";
+    };
+
+    terminal = optionalAttrs (userCfg.shell != null) {
+      # mynixos DECLARES the shell (my/users/users/mynixos-darwin.nix makes it
+      # zsh, mynixos-linux.nix bash) but deliberately leaves a macOS account's
+      # login shell alone -- so $SHELL, which is herdr's own fallback, is
+      # whatever Setup Assistant left in the directory service. Naming it makes
+      # herdr's panes honour the declaration instead of the directory service.
+      default_shell = userCfg.shell;
+    };
+
+    update = {
+      # The binary is a read-only store path. It cannot self-update, so this
+      # poll to herdr.dev could only ever tell us what the next lock bump would.
+      version_check = false;
+
+      # A different thing, off for a different reason: this one fetches
+      # agent-DETECTION manifests, so switching it off is a real trade -- herdr
+      # stops learning to recognise agents released after the pinned version, in
+      # exchange for making no unbidden network call. Turn it back on if
+      # detection goes stale before the next nixpkgs bump.
+      manifest_check = false;
+    };
+  };
+
+  configFor = userCfg:
+    (pkgs.formats.toml { }).generate "herdr-config.toml" (settingsFor userCfg);
+in
+{
+  config = {
+    home-manager.users = mapAttrs
+      (_name: userCfg:
+        mkIf (isHerdr userCfg) {
+          home.packages = [ pkgs.herdr ];
+
+          # The file, never the directory: herdr writes session.json and
+          # session-history.json next to config.toml, so ~/.config/herdr has to
+          # stay a real, writable directory. xdg.configFile symlinks per file,
+          # which is exactly what that needs.
+          #
+          # Consequence worth knowing: config.toml is a store path, so herdr's
+          # own settings screen cannot save to it. Settings changes come back
+          # here as Nix.
+          xdg.configFile."herdr/config.toml".source = configFor userCfg;
+        })
+      (activeUsers config.my.users);
+  };
+}

--- a/my/users/apps/multiplexers/herdr/linux.nix
+++ b/my/users/apps/multiplexers/herdr/linux.nix
@@ -1,0 +1,27 @@
+# Persistence for this app, on Linux.
+#
+# `my.system.persistence.features` is impermanence's collection point and is
+# declared only on Linux, so the write lives here rather than in ./default.nix,
+# which platforms/common.nix imports for both platforms. macOS has no
+# impermanence: nothing wipes the disk on reboot, so there is nothing to declare.
+#
+# Fleet-wide rather than per-user, because the app is chosen through a selector
+# (terminal.multiplexer) and so has no apps.* option to carry
+# persistedDirectories.
+#
+# Both directories are state, not config: .config/herdr holds session.json and
+# session-history.json alongside the store-symlinked config.toml, and .herdr is
+# the default worktree checkout root.
+#
+# Imported only by platforms/linux.nix.
+{ activeUsers, config, lib, ... }:
+
+with lib;
+
+let
+  isHerdr = userCfg: (userCfg.terminal.multiplexer or null) == "herdr";
+in
+{
+  config.my.system.persistence.features.userDirectories =
+    optionals (any isHerdr (attrValues (activeUsers config.my.users))) [ ".config/herdr" ".herdr" ];
+}

--- a/my/users/apps/multiplexers/herdr/options.nix
+++ b/my/users/apps/multiplexers/herdr/options.nix
@@ -1,0 +1,29 @@
+# herdr's entry in the terminal.multiplexer enum, and the default for the enum
+# as a whole.
+#
+# The default lives here rather than in my/users/terminal/options.nix because
+# this is mynixos's opinion about herdr specifically: this fleet runs coding
+# agents, and herdr is the only member of the enum that shows which agent is
+# running, which is waiting on you, and which is done. Drop herdr from
+# platforms/common.nix and the option loses its default, which surfaces as a
+# loud "used but not defined" -- the right failure, not a silent fallback to
+# something nobody chose.
+#
+# Only one declaration may carry a default (mergeOptionDecls rejects a second),
+# so this file and the base declaration are not interchangeable.
+{ lib, ... }:
+
+{
+  options.my.users = lib.mkOption {
+    type = lib.types.attrsOf (lib.types.submodule {
+      options.terminal = lib.mkOption {
+        type = lib.types.submodule {
+          options.multiplexer = lib.mkOption {
+            type = lib.types.enum [ "herdr" ];
+            default = "herdr";
+          };
+        };
+      };
+    });
+  };
+}

--- a/my/users/apps/multiplexers/tmux/options.nix
+++ b/my/users/apps/multiplexers/tmux/options.nix
@@ -1,0 +1,22 @@
+# tmux's entry in the terminal.multiplexer enum, declared beside the module that
+# implements it rather than in my/users/terminal/options.nix.
+#
+# lib.types.enum merges across declarations, so this adds "tmux" to whatever the
+# other multiplexers contribute. Deliberately no description and no default:
+# mergeOptionDecls rejects a second one of either, and the base declaration
+# already carries the description.
+{ lib, ... }:
+
+{
+  options.my.users = lib.mkOption {
+    type = lib.types.attrsOf (lib.types.submodule {
+      options.terminal = lib.mkOption {
+        type = lib.types.submodule {
+          options.multiplexer = lib.mkOption {
+            type = lib.types.enum [ "tmux" ];
+          };
+        };
+      };
+    });
+  };
+}

--- a/my/users/apps/multiplexers/zellij/options.nix
+++ b/my/users/apps/multiplexers/zellij/options.nix
@@ -1,0 +1,25 @@
+# zellij's entry in the terminal.multiplexer enum, declared beside the module
+# that implements it rather than in my/users/terminal/options.nix.
+#
+# lib.types.enum merges across declarations, so this adds "zellij" to whatever
+# the other multiplexers contribute. Deliberately no description and no default:
+# mergeOptionDecls rejects a second one of either, and the base declaration
+# already carries the description.
+#
+# This is still not an on/off switch -- see ./default.nix for why a second way
+# to say the same thing is exactly the bug that was fixed there.
+{ lib, ... }:
+
+{
+  options.my.users = lib.mkOption {
+    type = lib.types.attrsOf (lib.types.submodule {
+      options.terminal = lib.mkOption {
+        type = lib.types.submodule {
+          options.multiplexer = lib.mkOption {
+            type = lib.types.enum [ "zellij" ];
+          };
+        };
+      };
+    });
+  };
+}

--- a/my/users/apps/terminals/wezterm/default.nix
+++ b/my/users/apps/terminals/wezterm/default.nix
@@ -45,17 +45,18 @@ in
                 -- Terminal settings
                 config.enable_wayland = true
 
-                config.window_background_opacity = 0.70
-
                 -- Transparency is only legible when something blurs what shows
-                -- through. On Linux the compositor does that pass, so opacity
-                -- alone is enough; macOS has no equivalent, and the same 0.70
-                -- reads as plain see-through over whatever is behind the window.
+                -- through. On Linux the compositor does that pass, so 0.70 reads
+                -- as depth rather than as see-through.
                 --
-                -- wezterm draws its own surface with wgpu and adopts no AppKit
-                -- materials, so the system Liquid Glass look is not available to
-                -- it. This is the native blur it does expose.
-                ${optionalString isDarwin "config.macos_window_background_blur = 30"}
+                -- macOS has no equivalent. wezterm draws its own surface with
+                -- wgpu and adopts no AppKit materials, so the system Liquid Glass
+                -- look is not available to it, and macos_window_background_blur
+                -- -- the only native blur it exposes -- was not enough at any
+                -- setting: 0.70 still read as plain see-through over whatever
+                -- happened to be behind the window. Opaque there instead. A
+                -- legible terminal beats a transparent one.
+                config.window_background_opacity = ${if isDarwin then "1.0" else "0.70"}
                 config.hide_tab_bar_if_only_one_tab = true
                 config.default_cursor_style = 'BlinkingBlock'
                 config.cursor_blink_rate = 200
@@ -83,8 +84,15 @@ in
                   -- keeps this correct for root and for any shell, not just an
                   -- interactive login one. Linux needs none of this: the system
                   -- profile aggregates terminfo and the lookup already succeeds.
+                  -- weztermPackage, not pkgs.wezterm: `terminal.package` decides
+                  -- which wezterm is INSTALLED, and terminfo that describes a
+                  -- different build is the exact mismatch this block exists to
+                  -- prevent. `.terminfo` is a passthru and survives override /
+                  -- overrideAttrs; a package without one fails evaluation here,
+                  -- which is louder and better than silently pointing at the
+                  -- wrong build.
                   config.set_environment_variables = {
-                    TERMINFO_DIRS = '${pkgs.wezterm.terminfo}/share/terminfo:/usr/share/terminfo',
+                    TERMINFO_DIRS = '${weztermPackage.terminfo}/share/terminfo:/usr/share/terminfo',
                   }
                 ''}
                 config.check_for_updates = false

--- a/my/users/terminal/default.nix
+++ b/my/users/terminal/default.nix
@@ -50,6 +50,7 @@ in
 
               btm = "btop";
               zj = "zellij";
+              hr = "herdr";
               cvp = "cava-peaks";
               t = "tree -C";
 

--- a/my/users/terminal/mynixos.nix
+++ b/my/users/terminal/mynixos.nix
@@ -50,7 +50,12 @@
           # Fun/Eye candy
           fun.pipes.enable = lib.mkDefault false;
 
-          # Note: Multiplexers (zellij, tmux) are controlled by terminal.multiplexer setting, not as apps
+          # Note: Multiplexers (herdr, zellij, tmux) are controlled by the
+          # terminal.multiplexer setting, not as apps. Each one contributes its
+          # own name to that enum from my/users/apps/multiplexers/*/options.nix,
+          # and herdr's declaration also carries the enum's default -- so the
+          # default deliberately does NOT live in this file, which is gated on
+          # terminal.enable.
         };
       };
     }));

--- a/my/users/terminal/options.nix
+++ b/my/users/terminal/options.nix
@@ -12,9 +12,18 @@
           description = "Enable terminal tools";
         };
 
+        # Only "screen" and "none" are named here, because ./default.nix is what
+        # implements them. Every other multiplexer contributes its own name from
+        # its own options.nix (my/users/apps/multiplexers/*/options.nix):
+        # lib.types.enum merges across declarations, so the value set is the
+        # union of whatever platforms/*.nix actually imported.
+        #
+        # The default is owned the same way, by the multiplexer that claims it.
+        # It must stay ungated -- the multiplexer modules read this option for
+        # every active user, and a declared-but-undefined option throws on read
+        # rather than yielding null.
         multiplexer = lib.mkOption {
-          type = lib.types.enum [ "zellij" "tmux" "screen" "none" ];
-          default = "tmux";
+          type = lib.types.enum [ "screen" "none" ];
           description = "Terminal multiplexer";
         };
       };

--- a/platforms/common.nix
+++ b/platforms/common.nix
@@ -58,6 +58,15 @@ in
       # are not mkApp modules (so they cannot carry the option in their spec).
       ../my/users/apps/security/1password/options.nix
       ../my/users/apps/ai/claude-code/options.nix
+      ../my/users/apps/git/options.nix
+      ../my/users/apps/communication/discord/options.nix
+
+      # Each multiplexer contributes its own name to the terminal.multiplexer
+      # enum (lib.types.enum merges across declarations), so importing one here
+      # is what makes it selectable. herdr's also carries the enum's default.
+      ../my/users/apps/multiplexers/tmux/options.nix
+      ../my/users/apps/multiplexers/zellij/options.nix
+      ../my/users/apps/multiplexers/herdr/options.nix
 
       (mkOptionsModule ../my/fonts/options.nix { inherit lib; })
 
@@ -158,6 +167,7 @@ in
       # Multiplexers
       ../my/users/apps/multiplexers/tmux
       ../my/users/apps/multiplexers/zellij
+      ../my/users/apps/multiplexers/herdr
 
       # Network
       ../my/users/apps/network/termscp

--- a/platforms/darwin.nix
+++ b/platforms/darwin.nix
@@ -100,5 +100,11 @@ in
     # 1Password: the .app bundle. The Linux side uses programs._1password{,-gui},
     # which nix-darwin does not declare.
     ../my/users/apps/security/1password/darwin.nix
+
+    # Discord: a Homebrew cask here, the nixpkgs derivation on Linux. nixpkgs
+    # stages native modules inside the signed bundle, which breaks the code
+    # signature and makes macOS refuse to launch it -- see the file for the
+    # codesign output.
+    ../my/users/apps/communication/discord/darwin.nix
   ];
 }

--- a/platforms/linux.nix
+++ b/platforms/linux.nix
@@ -211,6 +211,11 @@ in
     ../my/users/apps/terminals/wezterm/linux.nix
     ../my/users/apps/file-managers/yazi/linux.nix
     ../my/users/apps/multiplexers/zellij/linux.nix
+    ../my/users/apps/multiplexers/herdr/linux.nix
+    # Discord: the nixpkgs derivation. macOS gets a Homebrew cask instead,
+    # because nixpkgs breaks the bundle's code signature -- the darwin half of
+    # this app explains why at length
+    ../my/users/apps/communication/discord
     ../my/secrets/linux.nix
     ../my/users/apps/art/krita
     ../my/users/apps/art/gimp

--- a/scripts/module-coverage.sh
+++ b/scripts/module-coverage.sh
@@ -19,10 +19,19 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # the handful of hardware-profile paths it exports as lib.hardware, so scraping
 # it here reports near-zero coverage.
 extract_imported_modules() {
+  # Comments are stripped FIRST. The pattern matches any `../my/...` text, so a
+  # comment naming a module path -- ordinary, since that is how one module points
+  # at its counterpart on the other platform -- was read as an import. Worse, `.`
+  # is in the character class, so a path ending a sentence captured the full stop
+  # too and yielded a module directory that does not exist, which `find` then
+  # failed on under `set -e`.
+  #
   # -E rather than -P: the pattern needs no PCRE, and BSD grep (macOS, now a
   # supported platform) has no -P.
-  grep -ohE '\.\./my/[a-zA-Z0-9_./-]+' "$REPO_ROOT"/platforms/*.nix |
+  sed 's/#.*//' "$REPO_ROOT"/platforms/*.nix |
+    grep -ohE '\.\./my/[a-zA-Z0-9_./-]+' |
     sed 's|^\.\./||' |
+    sed 's|\.$||' |
     sort -u
 }
 

--- a/tests/darwin-smoke.nix
+++ b/tests/darwin-smoke.nix
@@ -128,6 +128,21 @@ in
       (c.home-manager.users.smoke.launchd.agents ? keepingyouawake)
       "keepingyouawake should register a launchd user agent";
 
+  # Discord is the one app whose darwin half deliberately is NOT a derivation:
+  # nixpkgs stages native modules inside the signed bundle, which breaks the code
+  # signature and makes macOS refuse to launch it. Assert both halves of that
+  # decision -- the cask IS declared, and no nix discord sneaks in -- because a
+  # well-meaning "just put pkgs.discord back" is exactly the regression here.
+  darwin-smoke-discord =
+    let c = darwinConfig { users.smoke.apps.communication.messaging.discord.enable = true; };
+    in
+    check "discord"
+      (builtins.elem "discord" c.my.homebrew.casks
+        && !(builtins.any (p: (p.pname or "") == "discord") c.environment.systemPackages)
+        && !(builtins.any (p: (p.pname or "") == "discord")
+        c.home-manager.users.smoke.home.packages))
+      "discord on darwin should be a homebrew cask and never a nix package";
+
   # 1Password's darwin half installs the .app and the CLI.
   darwin-smoke-1password =
     let c = darwinConfig { users.smoke.apps.security.passwords.onePassword.enable = true; };

--- a/tests/module-eval.nix
+++ b/tests/module-eval.nix
@@ -150,6 +150,44 @@ in
       let hm = config.home-manager.users.muxuser; in
       hm.programs.tmux.enable && !hm.programs.zellij.enable);
 
+  # herdr has no home-manager module, so its own module is what puts the package
+  # on PATH and writes the config -- assert both, not just mutual exclusion.
+  multiplexer-herdr = evalAssert "multiplexer-herdr"
+    {
+      networking.hostName = "test-mux-herdr";
+      my.users.muxuser = {
+        fullName = "Mux User";
+        description = "mux";
+        email = "mux@example.com";
+        terminal = { enable = true; multiplexer = "herdr"; };
+      };
+    }
+    (config:
+      let hm = config.home-manager.users.muxuser; in
+      builtins.any (p: (p.pname or "") == "herdr") hm.home.packages
+      && hm.xdg.configFile ? "herdr/config.toml"
+      && !hm.programs.zellij.enable
+      && !hm.programs.tmux.enable);
+
+  # The point of the whole arrangement: terminal.multiplexer is declared in four
+  # files (my/users/terminal/options.nix plus one per multiplexer), and only
+  # herdr's carries a default. State no multiplexer at all and herdr must be
+  # what comes out -- if the enum declarations ever stop merging, this is the
+  # case that catches it.
+  multiplexer-default = evalAssert "multiplexer-default"
+    {
+      networking.hostName = "test-mux-default";
+      my.users.muxuser = {
+        fullName = "Mux User";
+        description = "mux";
+        email = "mux@example.com";
+        terminal.enable = true;
+      };
+    }
+    (config:
+      let user = config.my.users.muxuser; in
+      user.terminal.multiplexer == "herdr");
+
   user-features = evalTest "user-features" {
     networking.hostName = "test-user-features";
     my.users.testuser = {

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -2,13 +2,28 @@ _:
 {
   projectRootFile = "flake.nix";
 
-  # Nix formatting (same formatter you had before)
-  # Shell formatting and linting
-  # YAML formatting (for CI workflows)
   programs = {
+    # Nix
     nixpkgs-fmt.enable = true;
+
+    # statix and deadnix were separate CI jobs, which meant `nix fmt` could pass
+    # while CI failed on the same tree -- the drift this file exists to prevent.
+    # Run from here they are part of `nix flake check`'s `formatting` check, so
+    # the local command and the workflow cannot disagree.
+    statix.enable = true;
+    deadnix = {
+      enable = true;
+      # An underscore prefix is how this tree already says "bound, deliberately
+      # unused" (`_name:` in every mapAttrs, `_final: prev:` in the overlays), so
+      # honouring it is not a loosening -- it is the existing convention.
+      no-underscore = false;
+    };
+
+    # Shell
     shfmt.enable = true;
     shellcheck.enable = true;
+
+    # YAML (CI workflows)
     yamlfmt.enable = true;
   };
 }


### PR DESCRIPTION
Four changes turning on one idea: **an option belongs beside the implementation that makes it true.**

## Multiplexers — a colocated enum

`terminal.multiplexer` is no longer one list in `my/users/terminal/options.nix`. That file now declares only `"screen"` and `"none"` — what it implements — and each multiplexer contributes its own name from its own `options.nix`. `lib.types.enum` merges across declarations, so the value set is exactly what `platforms/*.nix` imported.

Verified against the real module tree via `mkSystem`, not a model of it: default resolves to `herdr`, `zellij`/`tmux`/`screen` still resolve, `"nope"` is still a type error.

herdr's declaration carries the default, replacing tmux — this fleet runs coding agents and herdr is the only member of the enum that surfaces agent state. The default is deliberately **not** in the `mynixos.nix` injector, which is gated on `terminal.enable`: the multiplexer modules read this option for every active user, and a declared-but-undefined option *throws* on read rather than yielding null.

home-manager has no `programs.herdr`, so the module installs the package and generates `config.toml` against the schema from `herdr --default-config`. Only settings that would be wrong for a Nix-managed install are stated.

## Discord — cask on darwin, derivation on Linux

Not a matter of taste. nixpkgs stages Discord's native modules inside the signed bundle:

```
$ codesign --verify --strict <store-path>/Applications/Discord.app
a sealed resource is missing or invalid
file added: .../Contents/Resources/modules/discord_rpc/index.js
```

macOS then refuses to launch it ("Discord is damaged"), and the bundle has no valid identity so it cannot reach its own data in `~/Library/Application Support/discord`, which macOS protects per-app. The CLI wrapper fails separately — a pre-launch helper runs under a Nix-store `python3`, TCC denies it with `EPERM`, and the wrapper is `bash -e`. Not fixable downstream: any bundle change breaks the seal.

1Password and KeepingYouAwake were checked with the same command; both verify. Discord is the only one.

## wezterm opacity, and lint placement

wezterm is opaque on macOS — `macos_window_background_blur` was not enough at any setting. Linux keeps `0.70`; a compositor does the blur pass there.

statix and deadnix move into `treefmt.nix` and stop being a separate CI job, so `nix fmt` and `nix flake check` can no longer disagree. **Note they now edit rather than report.** CI also gains a Nix store cache; it rebuilt the whole suite every run.

## Deliberately not adopted from rust-template

`devenv` + `tasks."test:*"` + `enterTest`. `nix flake check` already *is* that pattern here — the `checks` output is the suite. Adding devenv would create a second entry point that can drift from `checks`, which is the exact failure that template's comments warn about.

## Tests

125 checks green, including two new ones: `multiplexer-default` (stating no multiplexer must yield herdr — the case that catches the enum merge silently breaking) and `darwin-smoke-discord` (cask declared **and** no nix discord sneaks back in).

Also carries the in-progress `apps.dev.tools.git.protocol` work, at the author's request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)