### PR TITLE
chore(deps): vogix 0.8.3

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -697,11 +697,11 @@
         "vogix16-themes": "vogix16-themes"
       },
       "locked": {
-        "lastModified": 1782867631,
-        "narHash": "sha256-2KFYsNve+D3sm6V9uZx/XLTU/t6J+Xb/E7BslP+O2SE=",
+        "lastModified": 1786403769,
+        "narHash": "sha256-rw8lPEGE/DkB8i0g2EcnhekrnyyWrUB3TIFFNGrYptM=",
         "owner": "i-am-logger",
         "repo": "vogix",
-        "rev": "9135993fdeb3b0771d091b49e3a5b8f7c41a754f",
+        "rev": "8e238a1fa7c74f046536119fdd03884261ca686f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Picks up i-am-logger/vogix#186.

The reason to take it now: vogix's home-manager module computed its templates hash by reading a derivation, which is import-from-derivation — evaluating any configuration using vogix forced a build. On a cold store that fails outright, which is what has been keeping the Flake Check job red on i-am-logger/flake#19:

```
error: path '/nix/store/...-vogix-templates-hash.drv' is not valid
```

Verified against a real consumer: with this bump, /etc/nixos evaluates yoga under `--option allow-import-from-derivation false` and produces `mynixos-system-yoga-0.17.0.drv`. Before it failed with `cannot build '...-vogix-templates-hash.drv^out' during evaluation`.

0.8.3 also adds `appearance.prebuiltThemes`, which bounds how many themes get staged into the store (default `null` keeps staging everything, so nothing changes here unless a host opts in).

`nix flake check` passes.