### PR TITLE
feat(network): Tailscale SSH on Linux, Remote Login keys and hardening on darwin

### DIFF
--- a/my/network/openssh/darwin.nix
+++ b/my/network/openssh/darwin.nix
@@ -1,0 +1,51 @@
+# Inbound SSH on macOS: authorized keys + sshd hardening.
+#
+# The Linux module (./default.nix) sets users.users.<name>.openssh.authorizedKeys
+# from each user's YubiKey public keys; nix-darwin's openssh module has no such
+# option, so before this file NOTHING put a public key on a Mac and every inbound
+# hop was password-only. Keys land in /etc/ssh/authorized_keys.d/<user> -- the
+# same pattern NixOS uses -- rather than home-manager files in ~/.ssh, keeping a
+# system-level concern out of user homes and away from sshd's StrictModes rules
+# about ownership along symlink chains.
+#
+# Hardening lives in sshd_config.d/010-mynixos.conf. The 010 prefix is
+# load-bearing: macOS's stock sshd_config includes sshd_config.d/* FIRST and
+# OpenSSH takes the first value for each keyword, so this file must sort before
+# Apple's 100-macos.conf (which sets UsePAM yes and leaves password auth on).
+# nix-darwin's own services.openssh.extraConfig writes 100-nix-darwin.conf,
+# which sorts after Apple's file and loses -- that is why it is not used here.
+#
+# Gated on services.openssh.enable: a Mac that has not turned on Remote Login
+# gets neither keys nor config. Imported only by platforms/darwin.nix.
+{ config, lib, ... }:
+
+with lib;
+
+let
+  usersWithKeys = filterAttrs
+    (_: userCfg: (length (userCfg.yubikeys or [ ])) > 0)
+    config.my.users;
+
+  keysFor = userCfg:
+    filter (k: k != "") (map (yk: yk.sshPublicKey) userCfg.yubikeys);
+in
+{
+  config = mkIf config.services.openssh.enable {
+    environment.etc =
+      {
+        "ssh/sshd_config.d/010-mynixos.conf".text = ''
+          PasswordAuthentication no
+          KbdInteractiveAuthentication no
+          PermitRootLogin no
+          AuthenticationMethods publickey
+          AuthorizedKeysFile .ssh/authorized_keys /etc/ssh/authorized_keys.d/%u
+        '';
+      }
+      // mapAttrs'
+        (name: userCfg:
+          nameValuePair "ssh/authorized_keys.d/${name}" {
+            text = concatStringsSep "\n" (keysFor userCfg) + "\n";
+          })
+        usersWithKeys;
+  };
+}

--- a/my/network/openssh/darwin.nix
+++ b/my/network/openssh/darwin.nix
@@ -15,8 +15,10 @@
 # nix-darwin's own services.openssh.extraConfig writes 100-nix-darwin.conf,
 # which sorts after Apple's file and loses -- that is why it is not used here.
 #
-# Gated on services.openssh.enable: a Mac that has not turned on Remote Login
-# gets neither keys nor config. Imported only by platforms/darwin.nix.
+# Gated on services.openssh.enable == true: nix-darwin types that option as
+# nullOr bool, where null means "leave Remote Login alone" -- a Mac that has
+# not turned it on gets neither keys nor config. Imported only by
+# platforms/darwin.nix.
 { config, lib, ... }:
 
 with lib;
@@ -30,7 +32,7 @@ let
     filter (k: k != "") (map (yk: yk.sshPublicKey) userCfg.yubikeys);
 in
 {
-  config = mkIf config.services.openssh.enable {
+  config = mkIf (config.services.openssh.enable == true) {
     environment.etc =
       {
         "ssh/sshd_config.d/010-mynixos.conf".text = ''

--- a/my/network/options.nix
+++ b/my/network/options.nix
@@ -182,6 +182,25 @@
             description = "Enable routing features (client, server, both, or none)";
           };
 
+          ssh = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = ''
+              Run the Tailscale SSH server: inbound ssh over the tailnet is
+              authenticated by tailnet identity and the tailnet policy's `ssh`
+              rules instead of authorized_keys, so clients without local key
+              material (a phone, a machine with no security token) can log in.
+
+              Enforced with `tailscale set --ssh=true` rather than an `up`
+              flag: `tailscale up` RESETS every preference not named on its
+              command line, so a later hand-run `up` would silently switch the
+              SSH server off. `tailscale set` changes only what it names.
+
+              The classic sshd keeps running unchanged; tailscaled intercepts
+              port 22 on the tailscale interface only.
+            '';
+          };
+
           allowedTCPPorts = lib.mkOption {
             type = lib.types.listOf lib.types.port;
             default = [ ];

--- a/my/network/tailscale/default.nix
+++ b/my/network/tailscale/default.nix
@@ -97,6 +97,44 @@ in
       my.system.persistence.features.systemDirectories = [
         "/var/lib/tailscale"
       ];
+
+      # Keep the Tailscale SSH server on. `tailscale set` is what makes the
+      # option durable: it changes only the preference it names, while a
+      # hand-run `tailscale up` resets every preference absent from its
+      # command line and would silently disable SSH. Waits for the backend
+      # because `set` needs a running, logged-in tailscaled; when the node is
+      # logged out this exits cleanly and the preference is applied on the
+      # next activation after login.
+      systemd.services.tailscale-ssh-server = mkIf cfg.ssh {
+        description = "Enable the Tailscale SSH server preference";
+        wantedBy = [ "multi-user.target" ];
+        # Ordered after tailscale-autojoin: its `tailscale up` is itself a
+        # preference reset, so running `set` before it would be undone on the
+        # boot that joins. systemd ignores ordering against units that do not
+        # exist, so this is inert unless controlPlane = "headscale-local".
+        after = [ "tailscaled.service" "tailscale-autojoin.service" ];
+        wants = [ "tailscaled.service" ];
+
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+        };
+
+        path = [ config.services.tailscale.package pkgs.jq ];
+
+        script = ''
+          for i in $(seq 1 30); do
+            state=$(tailscale status --json 2>/dev/null | jq -r .BackendState 2>/dev/null || true)
+            case "$state" in
+              Running) tailscale set --ssh=true; exit 0 ;;
+              NeedsLogin|Stopped) echo "tailscaled is $state; SSH preference will apply after login"; exit 0 ;;
+            esac
+            sleep 1
+          done
+          echo "tailscaled backend not ready after 30s; SSH preference not applied" >&2
+          exit 0
+        '';
+      };
     }
 
     # Auto-join when headscale is on the same machine
@@ -164,6 +202,7 @@ in
             ${tailscale} up \
               --login-server=${localLoginServer} \
               --authkey=file:${keyFile} \
+              ${optionalString cfg.ssh "--ssh"} \
               ${optionalString cfg.exitNode "--advertise-exit-node"} \
               ${optionalString (cfg.advertiseRoutes != []) "--advertise-routes=${concatStringsSep "," cfg.advertiseRoutes}"}
 

--- a/platforms/darwin.nix
+++ b/platforms/darwin.nix
@@ -88,6 +88,10 @@ in
     # application firewall (`alf`) has no interface or address concept, so it
     # cannot express this.
     ../my/network/ssh-firewall
+
+    # Authorized keys + sshd hardening for Remote Login; pairs with the pf
+    # scoping above so what little sshd is reachable is also pubkey-only.
+    ../my/network/openssh/darwin.nix
   ]
 
   # -----------------------------------------------------------------------


### PR DESCRIPTION
Two halves of one goal — ssh freely between the hosts and from the iPad over the tailnet, with the Apple devices' "it was just simple to do" experience as the bar.

**`my.network.tailscale.ssh`** (Linux): runs the Tailscale SSH server, so inbound ssh over the tailnet is authenticated by tailnet identity and the policy's `ssh` rules — the iPad and the Mac need no key material to reach a NixOS host. Enforced with `tailscale set --ssh=true` from a oneshot: `tailscale up` resets every preference not named on its command line, so a later hand-run `up` would silently disable the SSH server; `set` changes only what it names. The oneshot waits for the backend and exits cleanly when logged out. Classic sshd (pubkey-only, YubiKey keys) keeps running as the fallback path; tailscaled intercepts :22 on the tailscale interface only.

**darwin Remote Login** (`my/network/openssh/darwin.nix`): nix-darwin's openssh module has no authorizedKeys option, so nothing ever put a public key on a Mac — inbound was password-only. Keys now land in `/etc/ssh/authorized_keys.d/<user>` (the NixOS pattern) from the same `yubikeys[*].sshPublicKey` data the Linux module reads, with hardening in `sshd_config.d/010-mynixos.conf`. The 010 prefix is load-bearing: macOS includes `sshd_config.d/*` first and OpenSSH keeps the first value per keyword, so the file must sort before Apple's `100-macos.conf` — nix-darwin's own `extraConfig` lands in `100-nix-darwin.conf` and loses. Gated on `services.openssh.enable == true` (nix-darwin types it `nullOr bool`).

Verified: `nix flake check` green including darwin-smoke (which caught the nullOr gate) and user-option-reach; on the consumer flake, yoga renders the `tailscale-ssh-server` oneshot and the Mac renders both YubiKey pubkeys in `authorized_keys.d/logger` plus the 010 hardening file.