### PR TITLE
fix(system): skip the localInputs override when the checkout matches the lock

### DIFF
--- a/my/system/scripts/default.nix
+++ b/my/system/scripts/default.nix
@@ -38,16 +38,49 @@ let
   # -- the latter simply builds from flake.lock. That is what makes this safe to
   # state once in a profile every host shares.
   #
-  # Announced every time. An overridden build is by definition not the build
-  # flake.lock describes, and discovering that from a puzzling rebuild result is
-  # far worse than reading one line.
+  # A checkout that is CLEAN and at exactly the locked revision is not
+  # overridden at all: the override would produce the identical build while
+  # making nix warn "not writing modified lock file" on every rebuild, and
+  # making the announcement below false. The override -- and the announcement
+  # -- fire only when the local checkout actually diverges from the lock.
+  # Discovering an overridden build from a puzzling rebuild result is far
+  # worse than reading one line.
+  #
+  # The locked revision is resolved by walking flake.lock's node graph from
+  # the root along the "/"-separated input path, following `follows` entries
+  # (which appear as arrays re-rooted at the top).
+  lockedRevFor = ''
+    locked_rev_for() {
+      ${pkgs.jq}/bin/jq -r --arg path "$1" '
+        def step($node; $rest):
+          if ($rest | length) == 0 then $node
+          else .nodes[$node].inputs[$rest[0]] as $next
+            | if $next == null then empty
+              elif ($next | type) == "array" then step(.root; $next + $rest[1:])
+              else step($next; $rest[1:])
+              end
+          end;
+        step(.root; $path | split("/")) as $node
+        | .nodes[$node].locked.rev // empty
+      ' "$FLAKE_DIR/flake.lock" 2>/dev/null
+    }
+  '';
+
   overrideInputs = ''
+    ${lockedRevFor}
     OVERRIDES=()
     ${concatStringsSep "\n" (mapAttrsToList
       (name: path: ''
         if [ -d ${escapeShellArg path} ]; then
-          OVERRIDES+=(--override-input ${escapeShellArg name} ${escapeShellArg path})
-          echo "  local input: ${name} -> ${path}" >&2
+          _locked=$(locked_rev_for ${escapeShellArg name})
+          _local=$(${pkgs.git}/bin/git -C ${escapeShellArg path} rev-parse HEAD 2>/dev/null || true)
+          if [ -n "$_locked" ] && [ "$_locked" = "$_local" ] \
+            && ${pkgs.git}/bin/git -C ${escapeShellArg path} diff-index --quiet HEAD -- 2>/dev/null; then
+            echo "  local input: ${name} matches flake.lock (''${_locked:0:8}), no override" >&2
+          else
+            OVERRIDES+=(--override-input ${escapeShellArg name} ${escapeShellArg path})
+            echo "  local input: ${name} -> ${path}" >&2
+          fi
         fi
       '')
       cfg.localInputs)}


### PR DESCRIPTION
Every `rebuild-system` on a host with `my.system.localInputs` printed nix's `warning: not writing modified lock file` twice — even when the local checkouts sat at exactly the locked revisions, where the override changes nothing and the script's "(this build does NOT match flake.lock)" line was simply false.

The scripts now resolve each input's locked revision by walking `flake.lock`'s node graph (nested paths like `mynixos/vogix` and `follows` arrays included — the resolver was verified against a real consumer lock for flat, nested, follows, missing and direct-input cases) and compare against the checkout's HEAD and cleanliness:

- clean + matching → **no override**, a truthful `matches flake.lock (<rev>), no override` line, no nix warning
- diverged (actually iterating) → override + announcement fire exactly as before

`--no-write-lock-file` was tried first and does not silence the warning on nix 2.34, which is what pushed the fix to the real cause instead of suppression.

Gates: statix, deadnix, treefmt, `nix flake check` all green.