### PR TITLE
fix: zero-warning evaluations — HM rebase, rust-overlay bump, fzf API

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -255,11 +255,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781297513,
-        "narHash": "sha256-yjMBNCcWi4zCUqUjrgp9VxIys+MAAfqH1wyENNn0h7w=",
+        "lastModified": 1786909652,
+        "narHash": "sha256-p2qr0S581YnQWS8VkEjQmSMhTY4NvTd+LnsDFtE1DF4=",
         "owner": "i-am-logger",
         "repo": "home-manager",
-        "rev": "ee91e5e635834893c5dd5bab70d16487f895a164",
+        "rev": "453728e345c9d8dd4d84320b92ee4888ea75b650",
         "type": "github"
       },
       "original": {
@@ -541,11 +541,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786420161,
-        "narHash": "sha256-PU4CY4GUCDFOoS67dGrc/fS6Y+d1cYZSh6nbgYqAAwE=",
+        "lastModified": 1786849542,
+        "narHash": "sha256-MS8cOa/ii1+QA8R3JWVzqEIoXimu9n50GwQDiBVTFOM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "3a646bd5daa3af78a78a1cb32329cb72d18fcae0",
+        "rev": "b211eadeba8b180da9453ec3413a8a3535c85b3f",
         "type": "github"
       },
       "original": {

--- a/my/users/apps/tools/fzf/default.nix
+++ b/my/users/apps/tools/fzf/default.nix
@@ -23,10 +23,14 @@ args:
       # makes the widgets usable in a repo.
       defaultCommand = "fd --type f --hidden --follow --exclude .git";
       defaultOptions = [ "--height 40%" "--layout=reverse" "--border" "--info=inline" ];
-      fileWidgetCommand = "fd --type f --hidden --follow --exclude .git";
-      fileWidgetOptions = [ "--preview 'bat -n --color=always --line-range :300 {}'" ];
-      changeDirWidgetCommand = "fd --type d --hidden --follow --exclude .git";
-      changeDirWidgetOptions = [ "--preview 'lsd --tree --depth 1 --color=always {}'" ];
+      fileWidget = {
+        command = "fd --type f --hidden --follow --exclude .git";
+        options = [ "--preview 'bat -n --color=always --line-range :300 {}'" ];
+      };
+      changeDirWidget = {
+        command = "fd --type d --hidden --follow --exclude .git";
+        options = [ "--preview 'lsd --tree --depth 1 --color=always {}'" ];
+      };
     };
   };
 }


### PR DESCRIPTION
Removes every remaining evaluation warning a consumer rebuild printed:

- **`stdenv.isLinux`/`isDarwin` deprecated** — traced (NIX_ABORT_ON_WARN + no-eval-cache; the flake eval cache and the fzf warnings both masked the trail first) to **rust-overlay's `mk-aggregated.nix`** reached through lanzaboote's pin. Upstream already uses `hostPlatform`; the nested `lanzaboote/rust-overlay` bump picks it up.
- **home-manager**: the webapps fork rebased onto current upstream master — the four webapps commits apply cleanly, and the base brings HM's own alias sweep plus current module APIs. Old head preserved at `backup/webapps-pre-hm-bump`.
- **fzf**: migrated to the renamed `fileWidget`/`changeDirWidget` submodules (the flat names warned through rename shims after the HM bump).

Verified: a consumer toplevel (yoga) evaluates with **zero** evaluation warnings under `--no-eval-cache`; statix, deadnix, treefmt, `nix flake check` all green.